### PR TITLE
Tolerate cppipe files that specify the path to load_data.csv

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,0 +1,17 @@
+version: 1.2
+workflows:
+  - subclass: WDL
+    primaryDescriptorPath: /cellprofiler_distributed/cellprofiler_distributed_utils.wdl
+    name: /cellprofiler_distributed/cellprofiler_distributed_utils
+  - subclass: WDL
+    primaryDescriptorPath: /cellprofiler_distributed/create_load_data.wdl
+    name: create_load_data
+  - subclass: WDL
+    primaryDescriptorPath: /cellprofiler_distributed/cpd_max_projection_pipeline.wdl
+    name: cpd_max_projection_pipeline
+  - subclass: WDL
+    primaryDescriptorPath: /cellprofiler_distributed/cp_illumination_pipeline.wdl
+    name: cp_illumination_pipeline
+  - subclass: WDL
+    primaryDescriptorPath: /cellprofiler_distributed/cpd_analysis_pipeline.wdl
+    name: cpd_analysis_pipeline

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -2,7 +2,7 @@ version: 1.2
 workflows:
   - subclass: WDL
     primaryDescriptorPath: /cellprofiler_distributed/cellprofiler_distributed_utils.wdl
-    name: /cellprofiler_distributed/cellprofiler_distributed_utils
+    name: cellprofiler_distributed_utils
   - subclass: WDL
     primaryDescriptorPath: /cellprofiler_distributed/create_load_data.wdl
     name: create_load_data

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -15,3 +15,6 @@ workflows:
   - subclass: WDL
     primaryDescriptorPath: /cellprofiler_distributed/cpd_analysis_pipeline.wdl
     name: cpd_analysis_pipeline
+  - subclass: WDL
+    primaryDescriptorPath: /mining/cytomining.wdl
+    name: cytomining

--- a/cellprofiler_distributed/cellprofiler_distributed_utils.wdl
+++ b/cellprofiler_distributed/cellprofiler_distributed_utils.wdl
@@ -433,6 +433,7 @@ task cellprofiler_pipeline_task {
     set -o errexit
     set -o pipefail
     set -o nounset
+    # send a trace of all fully resolved executed commands to stderr
     set -o xtrace
     
     export TMPDIR=/tmp

--- a/cellprofiler_distributed/cellprofiler_distributed_utils.wdl
+++ b/cellprofiler_distributed/cellprofiler_distributed_utils.wdl
@@ -423,14 +423,18 @@ task cellprofiler_pipeline_task {
 
   }
 
-  command {
+  command <<<
 
     # NOTE: cellprofiler pipelines might implicitly depend on the existence of
     #       specific files that are not passed as inputs at the command line:
     #       the "load_data.csv" file is one such file.
 
     # errors should cause the task to fail, not produce an empty output
-    set -e
+    set -o errexit
+    set -o pipefail
+    set -o nounset
+    set -o xtrace
+    
     export TMPDIR=/tmp
     mv ~{monitoring_script} monitoring_script.sh
     chmod a+rx monitoring_script.sh
@@ -470,6 +474,7 @@ task cellprofiler_pipeline_task {
     echo "Running cellprofiler ==================="
     # run cellprofiler pipeline
     cellprofiler --run --run-headless \
+      --data-file=~{load_data_csv} \
       -p ~{cppipe_file}  \
       -o output \
       -i $csv_dir
@@ -483,7 +488,7 @@ task cellprofiler_pipeline_task {
     echo "Directory containing output tarball ============================"
     ls -lah
 
-  }
+  >>>
 
   output {
     File log = stdout()

--- a/cellprofiler_distributed/cp_illumination_pipeline.wdl
+++ b/cellprofiler_distributed/cp_illumination_pipeline.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/deflaux/cellprofiler-on-Terra/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
+import "https://raw.githubusercontent.com/broadinstitute/cellprofiler-on-Terra/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
 
 ## Copyright Broad Institute, 2021
 ##

--- a/cellprofiler_distributed/cp_illumination_pipeline.wdl
+++ b/cellprofiler_distributed/cp_illumination_pipeline.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://api.firecloud.org/ga4gh/v1/tools/bayer-pcl-cell-imaging:cellprofiler_distributed_utils.wdl/versions/8/plain-WDL/descriptor" as util
+import "https://github.com/deflaux/cellprofiler-on-Terra/blob/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
 
 ## Copyright Broad Institute, 2021
 ##

--- a/cellprofiler_distributed/cp_illumination_pipeline.wdl
+++ b/cellprofiler_distributed/cp_illumination_pipeline.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://github.com/deflaux/cellprofiler-on-Terra/blob/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
+import "https://raw.githubusercontent.com/deflaux/cellprofiler-on-Terra/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
 
 ## Copyright Broad Institute, 2021
 ##

--- a/cellprofiler_distributed/cpd_analysis_pipeline.wdl
+++ b/cellprofiler_distributed/cpd_analysis_pipeline.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/deflaux/cellprofiler-on-Terra/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
+import "https://raw.githubusercontent.com/broadinstitute/cellprofiler-on-Terra/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
 
 ## Copyright Broad Institute, 2021
 ##

--- a/cellprofiler_distributed/cpd_analysis_pipeline.wdl
+++ b/cellprofiler_distributed/cpd_analysis_pipeline.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://api.firecloud.org/ga4gh/v1/tools/bayer-pcl-cell-imaging:cellprofiler_distributed_utils.wdl/versions/11/plain-WDL/descriptor" as util
+import "https://github.com/deflaux/cellprofiler-on-Terra/blob/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
 
 ## Copyright Broad Institute, 2021
 ##

--- a/cellprofiler_distributed/cpd_analysis_pipeline.wdl
+++ b/cellprofiler_distributed/cpd_analysis_pipeline.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://github.com/deflaux/cellprofiler-on-Terra/blob/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
+import "https://raw.githubusercontent.com/deflaux/cellprofiler-on-Terra/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
 
 ## Copyright Broad Institute, 2021
 ##

--- a/cellprofiler_distributed/cpd_max_projection_pipeline.wdl
+++ b/cellprofiler_distributed/cpd_max_projection_pipeline.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/deflaux/cellprofiler-on-Terra/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
+import "https://raw.githubusercontent.com/broadinstitute/cellprofiler-on-Terra/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
 
 ## Copyright Broad Institute, 2021
 ##

--- a/cellprofiler_distributed/cpd_max_projection_pipeline.wdl
+++ b/cellprofiler_distributed/cpd_max_projection_pipeline.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://github.com/deflaux/cellprofiler-on-Terra/blob/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
+import "https://raw.githubusercontent.com/deflaux/cellprofiler-on-Terra/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
 
 ## Copyright Broad Institute, 2021
 ##

--- a/cellprofiler_distributed/cpd_max_projection_pipeline.wdl
+++ b/cellprofiler_distributed/cpd_max_projection_pipeline.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://api.firecloud.org/ga4gh/v1/tools/bayer-pcl-cell-imaging:cellprofiler_distributed_utils.wdl/versions/7/plain-WDL/descriptor" as util
+import "https://github.com/deflaux/cellprofiler-on-Terra/blob/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
 
 ## Copyright Broad Institute, 2021
 ##

--- a/cellprofiler_distributed/create_load_data.wdl
+++ b/cellprofiler_distributed/create_load_data.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/deflaux/cellprofiler-on-Terra/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
+import "https://raw.githubusercontent.com/broadinstitute/cellprofiler-on-Terra/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
 
 ## Copyright Broad Institute, 2021
 ##

--- a/cellprofiler_distributed/create_load_data.wdl
+++ b/cellprofiler_distributed/create_load_data.wdl
@@ -1,6 +1,7 @@
 version 1.0
 
-import "https://api.firecloud.org/ga4gh/v1/tools/bayer-pcl-cell-imaging:cellprofiler_distributed_utils.wdl/versions/6/plain-WDL/descriptor" as util
+import "https://github.com/deflaux/cellprofiler-on-Terra/blob/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
+
 ## Copyright Broad Institute, 2021
 ##
 ## LICENSING :

--- a/cellprofiler_distributed/create_load_data.wdl
+++ b/cellprofiler_distributed/create_load_data.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://github.com/deflaux/cellprofiler-on-Terra/blob/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
+import "https://raw.githubusercontent.com/deflaux/cellprofiler-on-Terra/master/cellprofiler_distributed/cellprofiler_distributed_utils.wdl" as util
 
 ## Copyright Broad Institute, 2021
 ##


### PR DESCRIPTION
This change fixes https://github.com/broadinstitute/cellprofiler-on-Terra/issues/14

It also:
* adds Dockstore configuration
* updates the imports from Broad Methods Repository to GitHub
* check for more types of bash script errors
* traces (logs) all command execution with expanded parameter values
* use `command <<< >>>` so that `~{}` is the only syntax for cromwell variable expansion

See method from my fork [in Dockstore](https://dockstore.org/workflows/github.com/deflaux/cellprofiler-on-Terra/cpd_analysis_pipeline:nd-use-imports-from-fork?tab=info) temporarily for testing purposes.

Here's a successful run of the analysis pipeline on one plate of images: https://app.terra.bio/#workspaces/vts-deflaux/jump-cp-deflaux-try-bayer-pcl-cell-imaging/job_history/6eebde69-6487-4f45-ac32-891e0c2e9ae7