### PR TITLE
Update to cytominer docker image and build file

### DIFF
--- a/mining/Dockerfile
+++ b/mining/Dockerfile
@@ -1,34 +1,26 @@
 FROM python:3.7
 
 LABEL maintainer="Stephen Fleming <sfleming@broadinstitute.org>"
-
-RUN curl -so ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
- && chmod +x ~/miniconda.sh \
- && ~/miniconda.sh -b -p /home/user/miniconda \
- && rm ~/miniconda.sh
-
-ENV PATH=/home/user/miniconda/bin:$PATH
 ENV CONDA_AUTO_UPDATE_CONDA=false
-
-# google cloud SDK and gsutil
-RUN curl -sSL https://sdk.cloud.google.com | bash
-RUN conda install -y -c conda-forge google-api-python-client oauth2client google-auth \
- google-cloud-sdk google-auth-oauthlib \
- && conda install -y -c anaconda gcc_linux-64 \
- && conda clean -ya \
- && pip install --no-cache-dir -U crcmod
+ENV PATH="/home/user/miniconda/bin:${PATH}"
+ENV PATH="/home/user/miniconda/bin:/root/google-cloud-sdk/bin:${PATH}"
+ENV PATH="/software:${PATH}"
+ENV TMPDIR=/tmp
 
 # add a monitoring script
 ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh \
     /software/monitor_script.sh
-RUN chmod a+rx /software/monitor_script.sh
 
-# local clones of the github repos for cytominer-database and pycytominer exist
+# local clones of the github repos for cytominer-database and pycytominer must exist
 ADD . /software
 
-# install cytominer-database and pycytominer
-RUN pip install /software/cytominer-database \
- && pip install /software/pycytominer
-
-ENV PATH=/software:$PATH
-ENV TMPDIR=/tmp
+RUN curl -so ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+ && chmod +x ~/miniconda.sh \
+ && ~/miniconda.sh -b -p /home/user/miniconda \
+ && rm ~/miniconda.sh \
+ && curl -sSL https://sdk.cloud.google.com | bash \
+ && chmod a+rx /software/monitor_script.sh \
+ && pip install /software/cytominer-database \
+ && pip install /software/pycytominer \
+ && rm -rf ~/.cache/pip \
+ && conda clean -ya

--- a/mining/build_docker.sh
+++ b/mining/build_docker.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# clone the latest repo for cytominer-databse and pycytominer
+if [[ -d cytominer-database ]]; then rm -r cytominer-database; fi
+if [[ -d pycytominer ]]; then rm -r pycytominer; fi
+git clone https://github.com/cytomining/cytominer-database.git cytominer-database
+git clone https://github.com/cytomining/pycytominer.git pycytominer
+
+# build image
+docker build . --tag cytomining:0.0.3


### PR DESCRIPTION
Rather routine update.  Consolidated Dockerfile and hopefully reduced the size of the image a bit.  Updated to the latest master branches of cytominer-database and pycytominer.

Created a `build_docker.sh` file to codify the process of pulling the necessary repos and building the image.