### PR TITLE
Ensure no trailing slashes on input directories

### DIFF
--- a/cellprofiler_distributed/cp_illumination_pipeline.wdl
+++ b/cellprofiler_distributed/cp_illumination_pipeline.wdl
@@ -19,6 +19,9 @@ workflow cp_illumination_pipeline {
     # And the desired location of the outputs (optional)
     String output_illum_directory_gsurl = "${images_directory_gsurl}/illum"
 
+    # Ensure paths do not end in a trailing slash
+    String images_directory_gsurl = sub(images_directory_gsurl, "/+$", "")
+
   }
 
   # Define the input files, so that we use Cromwell's automatic file localization

--- a/cellprofiler_distributed/cpd_analysis_pipeline.wdl
+++ b/cellprofiler_distributed/cpd_analysis_pipeline.wdl
@@ -22,6 +22,10 @@ workflow cpd_analysis_pipeline {
     # And the desired location of the outputs
     String output_directory_gsurl
 
+    # Ensure paths do not end in a trailing slash
+    String images_directory_gsurl = sub(images_directory_gsurl, "/+$", "")
+    String output_directory_gsurl = sub(output_directory_gsurl, "/+$", "")
+
   }
 
   # Create an index to scatter

--- a/cellprofiler_distributed/cpd_max_projection_pipeline.wdl
+++ b/cellprofiler_distributed/cpd_max_projection_pipeline.wdl
@@ -22,6 +22,10 @@ workflow cpd_max_projection_distributed {
     # And the desired location of the outputs
     String output_directory_gsurl
 
+    # Ensure paths do not end in a trailing slash
+    String images_directory_gsurl = sub(images_directory_gsurl, "/+$", "")
+    String output_directory_gsurl = sub(output_directory_gsurl, "/+$", "")
+
   }
 
   # Create an index to scatter

--- a/cellprofiler_distributed/create_load_data.wdl
+++ b/cellprofiler_distributed/create_load_data.wdl
@@ -16,6 +16,9 @@ workflow create_load_data {
     String images_directory_gsurl
     String? file_extension = ".tiff"
 
+    # Ensure path does not end in a trailing slash
+    String images_directory_gsurl = sub(images_directory_gsurl, "/+$", "")
+
   }
 
   # Define the input files, so that we use Cromwell's automatic file localization

--- a/cellprofiler_single_vm/cellprofiler_pipeline.wdl
+++ b/cellprofiler_single_vm/cellprofiler_pipeline.wdl
@@ -22,6 +22,10 @@ workflow cellprofiler_pipeline {
     # The XML file from the microscope
     String xml_file
 
+    # Ensure paths do not end in a trailing slash
+    String input_directory_gsurl = sub(input_directory_gsurl, "/+$", "")
+    String output_directory_gsurl = sub(output_directory_gsurl, "/+$", "")
+
   }
 
   # Define the input files, so that we use Cromwell's automatic file localization


### PR DESCRIPTION
Removes trailing slashes from directory names that are input by the user.  These can currently interfere with path naming and cause an error.

Should fix #12 , but not yet actually tested by me.