### PR TITLE
Fix string images directory

### DIFF
--- a/cellprofiler_distributed/cp_illumination_pipeline.wdl
+++ b/cellprofiler_distributed/cp_illumination_pipeline.wdl
@@ -17,17 +17,17 @@ workflow cp_illumination_pipeline {
     String? file_extension = ".tiff"
 
     # And the desired location of the outputs (optional)
-    String output_illum_directory_gsurl = "${images_directory_gsurl}/illum"
+    String output_illum_directory_gsurl = "${images_directory}/illum"
 
     # Ensure paths do not end in a trailing slash
-    String images_directory_gsurl = sub(images_directory_gsurl, "/+$", "")
+    String images_directory = sub(images_directory_gsurl, "/+$", "")
 
   }
 
   # Define the input files, so that we use Cromwell's automatic file localization
   call util.gsutil_ls as directory {
     input:
-      directory_gsurl=images_directory_gsurl,
+      directory_gsurl=images_directory,
       file_extension=file_extension,
   }
 
@@ -35,7 +35,7 @@ workflow cp_illumination_pipeline {
   call util.cellprofiler_pipeline_task as cellprofiler {
     input:
       all_images_files=directory.file_array,  # from util.gsutil_ls task
-      load_data_csv= images_directory_gsurl + "/load_data.csv",
+      load_data_csv= images_directory + "/load_data.csv",
       hardware_boot_disk_size_GB = 20,
       hardware_preemptible_tries = 2,
   }
@@ -47,12 +47,5 @@ workflow cp_illumination_pipeline {
       tarball=cellprofiler.tarball,
       destination_gsurl=output_illum_directory_gsurl,
   }
-
-
-#  output {
-#    File tarball = cellprofiler.tarball
-#    File log = cellprofiler.log
-#    String output_directory = output_illum_directory_gsurl
-#  }
 
 }

--- a/cellprofiler_distributed/cpd_analysis_pipeline.wdl
+++ b/cellprofiler_distributed/cpd_analysis_pipeline.wdl
@@ -23,15 +23,15 @@ workflow cpd_analysis_pipeline {
     String output_directory_gsurl
 
     # Ensure paths do not end in a trailing slash
-    String images_directory_gsurl = sub(images_directory_gsurl, "/+$", "")
-    String output_directory_gsurl = sub(output_directory_gsurl, "/+$", "")
+    String images_directory = sub(images_directory_gsurl, "/+$", "")
+    String output_directory = sub(output_directory_gsurl, "/+$", "")
 
   }
 
   # Create an index to scatter
   call util.scatter_index as idx {
     input:
-      load_data_csv= images_directory_gsurl + "/load_data_with_illum.csv",
+      load_data_csv= images_directory + "/load_data_with_illum.csv",
       splitby_metadata = splitby_metadata,
   }
 
@@ -39,9 +39,9 @@ workflow cpd_analysis_pipeline {
   scatter(index in idx.value) {
     call util.splitto_scatter as sp {
       input:
-        image_directory =  images_directory_gsurl,
-        illum_directory = images_directory_gsurl + "/illum",
-        load_data_csv = images_directory_gsurl + "/load_data_with_illum.csv",
+        image_directory =  images_directory,
+        illum_directory = images_directory + "/illum",
+        load_data_csv = images_directory + "/load_data_with_illum.csv",
         splitby_metadata = splitby_metadata,
         tiny_csv = "load_data_with_illum.csv",
         index = index,
@@ -58,7 +58,7 @@ workflow cpd_analysis_pipeline {
     call util.extract_and_gsutil_rsync {
       input:
         tarball=cellprofiler.tarball,
-        destination_gsurl=output_directory_gsurl + "/" + index,
+        destination_gsurl=output_directory + "/" + index,
     }
   }
 

--- a/cellprofiler_distributed/cpd_max_projection_pipeline.wdl
+++ b/cellprofiler_distributed/cpd_max_projection_pipeline.wdl
@@ -23,15 +23,15 @@ workflow cpd_max_projection_distributed {
     String output_directory_gsurl
 
     # Ensure paths do not end in a trailing slash
-    String images_directory_gsurl = sub(images_directory_gsurl, "/+$", "")
-    String output_directory_gsurl = sub(output_directory_gsurl, "/+$", "")
+    String images_directory = sub(images_directory_gsurl, "/+$", "")
+    String output_directory = sub(output_directory_gsurl, "/+$", "")
 
   }
 
   # Create an index to scatter
   call util.scatter_index as idx {
     input:
-      load_data_csv= images_directory_gsurl + "/load_data.csv",
+      load_data_csv= images_directory + "/load_data.csv",
       splitby_metadata = splitby_metadata,
   }
 
@@ -39,9 +39,9 @@ workflow cpd_max_projection_distributed {
   scatter(index in idx.value) {
     call util.splitto_scatter as sp {
       input:
-        image_directory =  images_directory_gsurl,
+        image_directory =  images_directory,
         illum_directory = "/illum",  # default
-        load_data_csv = images_directory_gsurl + "/load_data.csv",
+        load_data_csv = images_directory + "/load_data.csv",
         splitby_metadata = splitby_metadata,
         tiny_csv = "load_data.csv",
         index = index,
@@ -58,7 +58,7 @@ workflow cpd_max_projection_distributed {
     call util.extract_and_gsutil_rsync {
       input:
         tarball=cellprofiler.tarball,
-        destination_gsurl=output_directory_gsurl,
+        destination_gsurl=output_directory,
     }
   }
 
@@ -66,22 +66,22 @@ workflow cpd_max_projection_distributed {
   # and they are saved in the same folder
   call util.filter_csv as script {
     input:
-      full_load_data_csv= images_directory_gsurl + "/load_data.csv",
-      full_load_data_with_illum_csv= images_directory_gsurl + "/load_data_with_illum.csv",
+      full_load_data_csv= images_directory + "/load_data.csv",
+      full_load_data_with_illum_csv= images_directory + "/load_data_with_illum.csv",
   }
 
   # Save load_data.csv file
   call util.gsutil_delocalize as save_load_data {
     input:
       file=script.load_data_csv,
-      destination_gsurl=output_directory_gsurl,
+      destination_gsurl=output_directory,
   }
 
   # Save load_data_will_illum.csv file
   call util.gsutil_delocalize as save_illum {
     input:
       file=script.load_data_with_illum_csv,
-      destination_gsurl=output_directory_gsurl,
+      destination_gsurl=output_directory,
   }
 
 }

--- a/cellprofiler_distributed/create_load_data.wdl
+++ b/cellprofiler_distributed/create_load_data.wdl
@@ -17,21 +17,21 @@ workflow create_load_data {
     String? file_extension = ".tiff"
 
     # Ensure path does not end in a trailing slash
-    String images_directory_gsurl = sub(images_directory_gsurl, "/+$", "")
+    String images_directory = sub(images_directory_gsurl, "/+$", "")
 
   }
 
   # Define the input files, so that we use Cromwell's automatic file localization
   call util.gsutil_ls_to_file as directory {
     input:
-      directory_gsurl=images_directory_gsurl,
+      directory_gsurl=images_directory,
       file_extension=file_extension,
   }
 
   # Create the load_data.csv file
   call util.generate_load_data_csv as script {
     input:
-      xml_file = images_directory_gsurl + "/Index.idx.xml",
+      xml_file = images_directory + "/Index.idx.xml",
       stdout = directory.out
   }
 
@@ -39,14 +39,14 @@ workflow create_load_data {
   call util.gsutil_delocalize {
     input:
       file=script.load_data_csv,
-      destination_gsurl=images_directory_gsurl,
+      destination_gsurl=images_directory,
   }
 
   # Save load_data_will_illum.csv file
   call util.gsutil_delocalize as save_illum{
     input:
       file=script.load_data_with_illum_csv,
-      destination_gsurl=images_directory_gsurl,
+      destination_gsurl=images_directory,
   }
 
   output {

--- a/mining/cytomining.wdl
+++ b/mining/cytomining.wdl
@@ -15,6 +15,9 @@ task profiling {
     String cellprofiler_analysis_directory_gsurl
     String plate_id
 
+    # Ensure path does not end in a trailing slash
+    String cellprofiler_analysis_directory = = sub(cellprofiler_analysis_directory_gsurl, "/+$", "")
+
     # Pycytominer aggregation step
     String? aggregation_operation = "median"
 
@@ -27,6 +30,7 @@ task profiling {
 
     # Desired location of the outputs
     String output_directory_gsurl
+    String output_directory = = sub(output_directory_gsurl, "/+$", "")
 
     # Output filenames:
     String agg_filename = plate_id + "_aggregated_" + aggregation_operation + ".csv"
@@ -51,13 +55,13 @@ task profiling {
     monitor_script.sh > monitoring.log &
 
     # display for log
-    echo "Localizing data from ~{cellprofiler_analysis_directory_gsurl}"
+    echo "Localizing data from ~{cellprofiler_analysis_directory}"
     start=`date +%s`
     echo $start
 
     # localize the data
     mkdir -p /cromwell_root/data
-    gsutil -mq rsync -r -x ".*\.png$" ~{cellprofiler_analysis_directory_gsurl} /cromwell_root/data
+    gsutil -mq rsync -r -x ".*\.png$" ~{cellprofiler_analysis_directory} /cromwell_root/data
     wget -O ingest_config.ini https://raw.githubusercontent.com/broadinstitute/cytominer_scripts/master/ingest_config.ini
     wget -O indices.sql https://raw.githubusercontent.com/broadinstitute/cytominer_scripts/master/indices.sql
 
@@ -92,8 +96,8 @@ task profiling {
     sqlite3 ~{plate_id}.sqlite < indices.sql
 
     # Copying sqlite
-    echo "Copying sqlite file to ~{output_directory_gsurl}"
-    gsutil cp ~{plate_id}.sqlite ~{output_directory_gsurl}/
+    echo "Copying sqlite file to ~{output_directory}"
+    gsutil cp ~{plate_id}.sqlite ~{output_directory}/
 
     # display for log
     end=`date +%s`
@@ -145,11 +149,11 @@ task profiling {
     echo "ls -lh ."
     ls -lh .
 
-    echo "Copying csv outputs to ~{output_directory_gsurl}"
-    gsutil cp ~{agg_filename} ~{output_directory_gsurl}/
-    gsutil cp ~{aug_filename} ~{output_directory_gsurl}/
-    gsutil cp ~{norm_filename} ~{output_directory_gsurl}/
-    gsutil cp monitoring.log ~{output_directory_gsurl}/
+    echo "Copying csv outputs to ~{output_directory}"
+    gsutil cp ~{agg_filename} ~{output_directory}/
+    gsutil cp ~{aug_filename} ~{output_directory}/
+    gsutil cp ~{norm_filename} ~{output_directory}/
+    gsutil cp monitoring.log ~{output_directory}/
 
     echo "Done."
 


### PR DESCRIPTION
Fix String images_directory input:
After removing trailing slashes from directory names, there were two input named the same.
Tested [here](https://app.terra.bio/#workspaces/bayer-pcl-cell-imaging/pcl-live-imaging/job_history/7b428e9f-9f5e-4053-9cfe-b0dc32cfdacc)
