### PR TITLE
Docker image that includes python scripts

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t us.gcr.io/broad-dsde-methods/python_cellprofiler_on_terra:0.0.1 -f docker/Dockerfile cellprofiler_distributed/scripts

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.7-slim
+
+LABEL org.opencontainers.image.authors="sfleming@broadinstitute.org"
+
+RUN pip install pandas pyyaml click numpy
+
+ADD *.py /scripts/
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
This is the code for making that `us.gcr.io/broad-dsde-methods/python_cellprofiler_on_terra:0.0.1` docker image.  Eventually, if we want to get fancy, we can try to get this docker image to auto-build and push to the Google Container Registry when changes are merged into master.  I don't exactly know how to do that currently (and how permissions for pushing are handled, etc.).  And I'm not sure how people handle versioning of the image in those cases.

@deflaux if you know how the above is accomplished, I'd be happy to get some pointers!

For now, we can keep it manual.  :) 