### PR TITLE
Update gsutil to copy files in parallel.

### DIFF
--- a/cellprofiler_distributed/cellprofiler_distributed_utils.wdl
+++ b/cellprofiler_distributed/cellprofiler_distributed_utils.wdl
@@ -105,7 +105,7 @@ task gsutil_delocalize {
 
   command {
     # Copy the file to the specified output location
-    gsutil cp -r ~{file} ~{full_destination_path}
+    gsutil -m cp -r ~{file} ~{full_destination_path}
   }
 
   runtime {


### PR DESCRIPTION
Since this task has a default configuration of 4 cpus, consider updating gsutil to perform the file copies in parallel to make use of more than one cpu.