### PR TITLE
Allow workflows to depend on task extract_and_gsutil_rsync

### DIFF
--- a/cellprofiler_distributed/cellprofiler_distributed_utils.wdl
+++ b/cellprofiler_distributed/cellprofiler_distributed_utils.wdl
@@ -264,8 +264,8 @@ task splitto_scatter {
 
   output {
     Array[String] array_output = read_lines(filename_text)
-    File filename_text = "${filename_text}"
-    File output_tiny_csv = "${tiny_csv}"
+    File output_filename_text = filename_text
+    File output_tiny_csv = tiny_csv
   }
 
   runtime {
@@ -373,6 +373,10 @@ task extract_and_gsutil_rsync {
     # this will overwrite previous outputs, but not delete other files.
 
     # ====================================================================
+  }
+
+  output {
+      String output_directory = destination_gsurl
   }
 
   runtime {


### PR DESCRIPTION
I am working on a new workflow that uses results from CellProfiler analysis as input to a next WDL task that also occurs within the scatter operation on wells. These two changes were needed for correct execution of that dependency.

1) Add a declared output variable to task extract_and_gsutil_rsync so that workflows may depend on its completion.

2) Also add a bug fix for the output from task splitto_scatter. Sometimes the chained task was correctly receiving the fully qualified value "gs://fc-...../filename_array.text" but other times it was only receiving "filename_array.text". These updates fix that issue.