### PR TITLE
Add sqlite3 to cytomining docker image

### DIFF
--- a/pipelines/mining/Dockerfile
+++ b/pipelines/mining/Dockerfile
@@ -24,3 +24,7 @@ RUN chmod a+rx /software/monitor_script.sh \
  && pip3 install cytominer-database==0.3.4 \
  && pip3 install pycytominer==0.2.0 \
  && rm -rf ~/.cache/pip
+
+# install sqlite3 \
+RUN apt-get update && apt-get install -y --no-install-recommends sqlite3 \
+ && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
For some reason the last attempt to make a `0.0.4` image was missing `sqlite3`, when it was present in previous versions.  Not sure how!  But it's explicitly included now.

Image hosted at
```
us.gcr.io/broad-dsde-methods/cytomining:0.0.4
```
over-writing the older attempt in #52 