### PR TITLE
CellProfiler workflow: optional scatter

### DIFF
--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -32,7 +32,7 @@ workflow cellprofiler_pipeline {
     String output_directory = sub(output_directory_gsurl, "/+$", "")
 
   }
-  Boolean do_scatter = splitby_metadata == ""  # true if splitby_metadata is empty
+  Boolean do_scatter = (splitby_metadata != "")  # true if splitby_metadata is not empty
 
   # Define the input files, so that we use Cromwell's automatic file localization
   call util.gsutil_ls_to_file as directory {
@@ -69,6 +69,8 @@ workflow cellprofiler_pipeline {
           destination_gsurl=output_directory,
       }
     }
+    Array[String] output_tarball_array = [cellprofiler.tarball]
+    Array[String] output_log_array = [cellprofiler.log]
 
   }
 
@@ -87,10 +89,8 @@ workflow cellprofiler_pipeline {
       call util.splitto_scatter as sp {
         input:
           image_directory=input_directory,
-#          illum_directory=input_directory + "/illum",
           load_data_csv=script.load_data_csv,
           splitby_metadata=splitby_metadata,
-          tiny_csv="load_data.csv",
           index=index,
       }
 
@@ -110,12 +110,14 @@ workflow cellprofiler_pipeline {
       }
 
     }
+    Array[String] output_tarball_array = cellprofiler.tarball
+    Array[String] output_log_array = cellprofiler.log
 
   }
 
   output {
-    File tarball = if do_scatter then "none" else cellprofiler.tarball
-    File log = if do_scatter then "none" else cellprofiler.log
+    File tarballs = output_tarball_array
+    File logs = output_log_array
     String output_path = output_directory
   }
 

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -21,7 +21,7 @@ workflow cellprofiler_pipeline {
     String output_directory_gsurl = ""
 
     # The XML file from the microscope
-    String xml_file
+    String? xml_file  # this is only required if load_data_csv is not specified
 
     # Specify Metadata used to distribute the analysis: Well (default), Site...
     # An empty string "" will use a single VM

--- a/utils/cellprofiler_distributed_utils.wdl
+++ b/utils/cellprofiler_distributed_utils.wdl
@@ -253,13 +253,13 @@ task splitto_scatter {
     pip install pandas ipython numpy click
 
     python /scripts/cpd_utils.py splitto-scatter \
-      --image-directory ~{image_directory} \
-      --illum-directory ~{illum_directory} \
-      --csv-file ~{load_data_csv} \
-      --splitby-metadata ~{splitby_metadata} \
-      --index ~{index} \
-      --output-text ~{filename_text} \
-      --output-csv ~{tiny_csv}
+      ~{"--image-directory " + image_directory} \
+      ~{"--illum-directory " + illum_directory} \
+      ~{"--csv-file " + load_data_csv} \
+      ~{"--splitby-metadata " + splitby_metadata} \
+      ~{"--index " + index} \
+      ~{"--output-text " + filename_text} \
+      ~{"--output-csv " + tiny_csv}
 
   }
 

--- a/utils/cellprofiler_distributed_utils.wdl
+++ b/utils/cellprofiler_distributed_utils.wdl
@@ -245,7 +245,7 @@ task splitto_scatter {
     Int hardware_memory_GB = 15
     Int hardware_cpu_count = 4
 
-    String tiny_csv
+    String tiny_csv = "load_data.csv"
     String filename_text = "filename_array.text"
   }
 


### PR DESCRIPTION
This is an attempt to unify the "distributed" and "single-VM" CellProfiler workflows into the same workflow.  It will scatter if you specify the input `splitby_metadata` as something other than `""`.

It has the option to copy outputs to a google bucket.

But it will also work without copying to a google bucket: the output files are outputs of the workflow (i.e. they will be copied to the Cromwell execution directory).  The outputs are arrays.  Each array element will be one scatter unit, if scattering occurs, and otherwise the array will have only one element.

Totally untested.