### PR TITLE
CellProfiler workflow: optional scatter

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -15,3 +15,6 @@ workflows:
   - subclass: WDL
     primaryDescriptorPath: /pipelines/mining/cytomining.wdl
     name: cytomining
+  - subclass: WDL
+    primaryDescriptorPath: /pipelines/cellprofiler/cellprofiler_pipeline.wdl
+    name: cellprofiler

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -42,15 +42,14 @@ workflow cellprofiler_pipeline {
   }
 
   # The load_data.csv file
-  String load_data_csv_file = load_data_csv
-  if (load_data_csv_file == "") {
+  if (load_data_csv == "") {
     call util.generate_load_data_csv as script {
       input:
         xml_file=xml_file,
         stdout=directory.out,
     }
-    String load_data_csv_file = script.load_data_csv
   }
+  String load_data_csv_file = select_first(script.load_data_csv, load_data_csv)
 
   if (!do_scatter) {
 

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -51,6 +51,11 @@ workflow cellprofiler_pipeline {
 
   # The load_data.csv file
   if (load_data_csv == "") {
+    if (config_yaml == "") {
+      echo "ERROR: Missing load_data.csv or config.yml (to generate it)."
+      echo "Provide either the load_data csv file or the necessary config yaml to generate it and try again"
+      exit 1
+    }
     call util.generate_load_data_csv as script {
       input:
         xml_file=xml_file,

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -52,9 +52,11 @@ workflow cellprofiler_pipeline {
   # The load_data.csv file
   if (load_data_csv == "") {
     if (config_yaml == "") {
-      echo "ERROR: Missing load_data.csv or config.yml (to generate it)."
-      echo "Provide either the load_data csv file or the necessary config yaml to generate it and try again"
-      exit 1
+      command <<<
+        echo "ERROR: Missing load_data.csv or config.yml (to generate it)."
+        echo "Provide either the load_data csv file or the necessary config yaml to generate it and try again"
+        exit 1
+      >>>
     }
     call util.generate_load_data_csv as script {
       input:

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -24,7 +24,8 @@ workflow cellprofiler_pipeline {
     String output_directory_gsurl = ""
 
     # Specify Metadata used to distribute the analysis: Well (default), Site...
-    # An empty string "" will use a single VM
+    # If do_scatter is false, this will run on a single VM and ignore splitby_metadata
+    Boolean do_scatter
     String splitby_metadata = "Metadata_Well"
     
     # Optional input: directory containing the .npy illumination correction images
@@ -43,7 +44,7 @@ workflow cellprofiler_pipeline {
   }
 
   # The single VM workflow
-  if (splitby_metadata == "") {
+  if (!do_scatter) {
 
     # Run CellProfiler pipeline
     call util.cellprofiler_pipeline_task as cellprofiler {
@@ -67,7 +68,7 @@ workflow cellprofiler_pipeline {
   }
 
   # The distributed workflow, running in parallel on many VMs
-  if (splitby_metadata != "") {
+  if (do_scatter) {
 
     # Create an index to scatter
     call util.scatter_index as idx {

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -79,7 +79,7 @@ workflow cellprofiler_pipeline {
     # Create an index to scatter
     call util.scatter_index as idx {
       input:
-        load_data_csv=script.load_data_csv,
+        load_data_csv=load_data_csv_file,
         splitby_metadata=splitby_metadata,
     }
 
@@ -89,7 +89,7 @@ workflow cellprofiler_pipeline {
       call util.splitto_scatter as sp {
         input:
           image_directory=input_directory,
-          load_data_csv=script.load_data_csv,
+          load_data_csv=load_data_csv_file,
           splitby_metadata=splitby_metadata,
           index=index,
       }

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -16,6 +16,9 @@ workflow cellprofiler_pipeline {
     String input_directory_gsurl
     String file_extension = ".tiff"
     String load_data_csv = ""  # leave blank to run generate_load_data_csv task
+    
+    # Cellprofiler pipeline 
+    File cppipe_file
 
     # And the desired location of the outputs (optional)
     String output_directory_gsurl = ""
@@ -58,6 +61,7 @@ workflow cellprofiler_pipeline {
       input:
         all_images_files=read_lines(directory.out),
         load_data_csv=load_data_csv_file,
+        cppipe_file=cppipe_file,
     }
 
     # Optionally delocalize outputs
@@ -97,6 +101,7 @@ workflow cellprofiler_pipeline {
         input:
           all_images_files=sp.array_output,
           load_data_csv=sp.output_tiny_csv,
+          cppipe_file=cppipe_file
       }
 
       # Optionally delocalize outputs

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -25,7 +25,7 @@ workflow cellprofiler_pipeline {
 
     # Specify Metadata used to distribute the analysis: Well (default), Site...
     # If do_scatter is false, this will run on a single VM and ignore splitby_metadata
-    Boolean do_scatter
+    Boolean do_scatter = true
     String splitby_metadata = "Metadata_Well"
     
     # Optional input: directory containing the .npy illumination correction images

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -51,13 +51,6 @@ workflow cellprofiler_pipeline {
 
   # The load_data.csv file
   if (load_data_csv == "") {
-    if (config_yaml == "") {
-      command <<<
-        echo "ERROR: Missing load_data.csv or config.yml (to generate it)."
-        echo "Provide either the load_data csv file or the necessary config yaml to generate it and try again"
-        exit 1
-      >>>
-    }
     call util.generate_load_data_csv as script {
       input:
         xml_file=xml_file,

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -49,7 +49,7 @@ workflow cellprofiler_pipeline {
         stdout=directory.out,
     }
   }
-  String load_data_csv_file = select_first(script.load_data_csv, load_data_csv)
+  String load_data_csv_file = select_first([script.load_data_csv, load_data_csv])
 
   if (!do_scatter) {
 
@@ -117,8 +117,8 @@ workflow cellprofiler_pipeline {
   Array[String] output_log_array = select_first([output_log_array_single, output_log_array_scattered])
 
   output {
-    File tarballs = output_tarball_array
-    File logs = output_log_array
+    Array[File] tarballs = output_tarball_array
+    Array[File] logs = output_log_array
     String output_path = output_directory
   }
 

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -23,11 +23,16 @@ workflow cellprofiler_pipeline {
     # The XML file from the microscope
     String? xml_file  # this is only required if load_data_csv is not specified
 
-  }
+    # Specify Metadata used to distribute the analysis: Well (default), Site...
+    # An empty string "" will use a single VM
+    String splitby_metadata = "Metadata_Well"
 
-  # Ensure paths do not end in a trailing slash
-  String input_directory = sub(input_directory_gsurl, "/+$", "")
-  String output_directory = sub(output_directory_gsurl, "/+$", "")
+    # Ensure paths do not end in a trailing slash
+    String input_directory = sub(input_directory_gsurl, "/+$", "")
+    String output_directory = sub(output_directory_gsurl, "/+$", "")
+
+  }
+  Boolean do_scatter = (splitby_metadata != "")  # true if splitby_metadata is not empty
 
   # Define the input files, so that we use Cromwell's automatic file localization
   call util.gsutil_ls_to_file as directory {
@@ -47,25 +52,72 @@ workflow cellprofiler_pipeline {
     String load_data_csv_file = script.load_data_csv
   }
 
-  # Run CellProfiler pipeline
-  call util.cellprofiler_pipeline_task as cellprofiler {
-    input:
-      all_images_files=read_lines(directory.out),  # from util.gsutil_ls_to_file task
-      load_data_csv=load_data_csv_file,
+  if (!do_scatter) {
+
+    # Run CellProfiler pipeline
+    call util.cellprofiler_pipeline_task as cellprofiler {
+      input:
+        all_images_files=read_lines(directory.out),
+        load_data_csv=load_data_csv_file,
+    }
+
+    # Optionally delocalize outputs
+    if (output_directory_gsurl != "") {
+      call util.extract_and_gsutil_rsync {
+        input:
+          tarball=cellprofiler.tarball,
+          destination_gsurl=output_directory,
+      }
+    }
+    Array[String] output_tarball_array = [cellprofiler.tarball]
+    Array[String] output_log_array = [cellprofiler.log]
+
   }
 
-  # Optionally delocalize outputs
-  if (output_directory != "") {
-    call util.extract_and_gsutil_rsync {
+  if (do_scatter) {
+
+    # Create an index to scatter
+    call util.scatter_index as idx {
       input:
-        tarball=cellprofiler.tarball,
-        destination_gsurl=output_directory,
+        load_data_csv=script.load_data_csv,
+        splitby_metadata=splitby_metadata,
     }
+
+    # Run CellProfiler pipeline scattered
+    scatter(index in idx.value) {
+
+      call util.splitto_scatter as sp {
+        input:
+          image_directory=input_directory,
+          load_data_csv=script.load_data_csv,
+          splitby_metadata=splitby_metadata,
+          index=index,
+      }
+
+      call util.cellprofiler_pipeline_task as cellprofiler {
+        input:
+          all_images_files=sp.array_output,
+          load_data_csv=sp.output_tiny_csv,
+      }
+
+      # Optionally delocalize outputs
+      if (output_directory_gsurl != "") {
+        call util.extract_and_gsutil_rsync {
+          input:
+            tarball=cellprofiler.tarball,
+            destination_gsurl=output_directory + "/" + index,
+        }
+      }
+
+    }
+    Array[String] output_tarball_array = cellprofiler.tarball
+    Array[String] output_log_array = cellprofiler.log
+
   }
 
   output {
-    File tarball = cellprofiler.tarball
-    File log = cellprofiler.log
+    File tarballs = output_tarball_array
+    File logs = output_log_array
     String output_path = output_directory
   }
 

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -16,6 +16,8 @@ workflow cellprofiler_pipeline {
     String input_directory_gsurl
     String file_extension = ".tiff"
     String load_data_csv = ""  # leave blank to run generate_load_data_csv task
+    String config_yaml = ""
+    String plate_id = ""
     
     # Cellprofiler pipeline 
     File cppipe_file
@@ -33,6 +35,9 @@ workflow cellprofiler_pipeline {
     # Ensure paths do not end in a trailing slash
     String input_directory = sub(input_directory_gsurl, "/+$", "")
     String output_directory = sub(output_directory_gsurl, "/+$", "")
+    
+    # Optional input: directory containing the .nyp illumination correction images
+    String illum_directory = "${input_directory}/illum"
 
   }
   Boolean do_scatter = (splitby_metadata != "")  # true if splitby_metadata is not empty
@@ -50,6 +55,8 @@ workflow cellprofiler_pipeline {
       input:
         xml_file=xml_file,
         stdout=directory.out,
+        config_yaml=config_yaml,
+        plate_id=plate_id,  
     }
   }
   String load_data_csv_file = select_first([script.load_data_csv, load_data_csv])
@@ -92,6 +99,7 @@ workflow cellprofiler_pipeline {
       call util.splitto_scatter as sp {
         input:
           image_directory=input_directory,
+          illum_directory=illum_directory,
           load_data_csv=load_data_csv_file,
           splitby_metadata=splitby_metadata,
           index=index,

--- a/utils/cellprofiler_distributed_utils.wdl
+++ b/utils/cellprofiler_distributed_utils.wdl
@@ -245,7 +245,7 @@ task splitto_scatter {
     Int hardware_memory_GB = 15
     Int hardware_cpu_count = 4
 
-    String tiny_csv
+    String tiny_csv = "load_data.csv"
     String filename_text = "filename_array.text"
   }
 
@@ -253,13 +253,13 @@ task splitto_scatter {
     pip install pandas ipython numpy click
 
     python /scripts/cpd_utils.py splitto-scatter \
-      --image-directory ~{image_directory} \
-      --illum-directory ~{illum_directory} \
-      --csv-file ~{load_data_csv} \
-      --splitby-metadata ~{splitby_metadata} \
-      --index ~{index} \
-      --output-text ~{filename_text} \
-      --output-csv ~{tiny_csv}
+      ~{"--image-directory " + image_directory} \
+      ~{"--illum-directory " + illum_directory} \
+      ~{"--csv-file " + load_data_csv} \
+      ~{"--splitby-metadata " + splitby_metadata} \
+      ~{"--index " + index} \
+      ~{"--output-text " + filename_text} \
+      ~{"--output-csv " + tiny_csv}
 
   }
 


### PR DESCRIPTION
This is an attempt to unify the "distributed" and "single-VM" CellProfiler workflows into the same workflow. It will scatter if you specify the input splitby_metadata as something other than "".

It has the option to copy outputs to a google bucket.

But it will also work without copying to a google bucket: the output files are outputs of the workflow (i.e. they will be copied to the Cromwell execution directory). The outputs are arrays. Each array element will be one scatter unit, if scattering occurs, and otherwise the array will have only one element.

Totally untested.