### PR TITLE
Update cytomining to JUMP/CP recipe

### DIFF
--- a/pipelines/mining/Dockerfile
+++ b/pipelines/mining/Dockerfile
@@ -5,11 +5,11 @@ LABEL maintainer="Stephen Fleming <sfleming@broadinstitute.org>"
 ENV HOME="/root" \
     TMPDIR="/tmp"
 
-# add a monitoring script
+# Add the monitoring script.
 ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh \
     /software/monitor_script.sh
 
-# gsutil with compiled crcmod
+# Install gsutil with compiled crcmod.
 ENV GOOGLE_CLOUD_CLI_VERSION="397.0.0" \
     PATH="${HOME}/google-cloud-sdk/bin:/software:${PATH}"
 RUN curl -so $HOME/google-cloud-cli.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GOOGLE_CLOUD_CLI_VERSION}-linux-x86_64.tar.gz \
@@ -19,18 +19,14 @@ RUN curl -so $HOME/google-cloud-cli.tar.gz https://dl.google.com/dl/cloudsdk/cha
  && rm $HOME/google-cloud-cli.tar.gz \
  && rm -rf ~/.cache/pip
 
-# cytominer-database
+# Install cytominer-database and a specific commit of pycytominr for the JUMP/CP cytomining recipe.
 RUN chmod a+rx /software/monitor_script.sh \
- && pip3 install cytominer-database==0.3.4 \
+ && pip3 install \
+     cytominer-database==0.3.4 \
+     git+https://github.com/cytomining/pycytominer@36241269c4293c24484986568ca16b2d7eb9e808 \
  && rm -rf ~/.cache/pip
 
-# Update to specific unreleased code JUMP/CP cytomining recipe
-RUN git clone https://github.com/cytomining/pycytominer.git \
- && cd pycytominer \
- && git checkout 36241269c4293c24484986568ca16b2d7eb9e808 \
- && python3 -m pip install -e .
-
-# install sqlite3 \
+# Install sqlite3.
 RUN apt-get update && apt-get install -y --no-install-recommends sqlite3 \
  && rm -rf /var/lib/apt/lists/*
  

--- a/pipelines/mining/Dockerfile
+++ b/pipelines/mining/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -so $HOME/google-cloud-cli.tar.gz https://dl.google.com/dl/cloudsdk/cha
  && rm $HOME/google-cloud-cli.tar.gz \
  && rm -rf ~/.cache/pip
 
-# Install cytominer-database and a specific commit of pycytominr for the JUMP/CP cytomining recipe.
+# Install cytominer-database and a specific commit of pycytominer for the JUMP/CP cytomining recipe.
 RUN chmod a+rx /software/monitor_script.sh \
  && pip3 install \
      cytominer-database==0.3.4 \

--- a/pipelines/mining/Dockerfile
+++ b/pipelines/mining/Dockerfile
@@ -19,12 +19,25 @@ RUN curl -so $HOME/google-cloud-cli.tar.gz https://dl.google.com/dl/cloudsdk/cha
  && rm $HOME/google-cloud-cli.tar.gz \
  && rm -rf ~/.cache/pip
 
-# cytominer-database and pycytominer
+# cytominer-database
 RUN chmod a+rx /software/monitor_script.sh \
  && pip3 install cytominer-database==0.3.4 \
- && pip3 install pycytominer==0.2.0 \
  && rm -rf ~/.cache/pip
+
+# Update to specific unreleased code JUMP/CP cytomining recipe
+RUN git clone https://github.com/cytomining/pycytominer.git \
+ && cd pycytominer \
+ && git checkout 36241269c4293c24484986568ca16b2d7eb9e808 \
+ && python3 -m pip install -e .
 
 # install sqlite3 \
 RUN apt-get update && apt-get install -y --no-install-recommends sqlite3 \
  && rm -rf /var/lib/apt/lists/*
+ 
+# Install the AWS CLI and install the credential-fetching script.
+RUN pip3 install awscli boto3 requests \
+ && rm -rf ~/.cache/pip
+COPY get_aws_credentials.py /opt/
+RUN chmod a+x /opt/get_aws_credentials.py    
+
+

--- a/pipelines/mining/cytomining.wdl
+++ b/pipelines/mining/cytomining.wdl
@@ -15,17 +15,19 @@ task profiling {
     String plate_id
 
     # Pycytominer aggregation step
-    String? aggregation_operation = "mean"
+    String aggregation_operation = "mean"
 
     # Pycytominer annotation step
-    File plate_map_tsv_file
-    String? plate_map_annotate_join_on = "['Metadata_well_position', 'Metadata_Well']"
-    File external_metadata_tsv_file
-    String? external_metadata_annotate_join_on = "Metadata_broad_sample"
+    File plate_map_file
+    String plate_map_join_col_left = "Metadata_well_position"
+    String plate_map_join_col_right = "Metadata_Well"
+    File external_metadata_file
+    String external_metadata_join_col_left
+    String external_metadata_join_col_right
 
     # Pycytominer normalize step
-    String? normalize_method = "mad_robustize"
-    Float? mad_robustize_epsilon = 0.0
+    String normalize_method = "mad_robustize"
+    Float mad_robustize_epsilon = 0.0
 
     # Desired location of the outputs
     String output_directory_url
@@ -36,12 +38,10 @@ task profiling {
     String? terra_aws_arn
 
     # Hardware-related inputs
-    Int? hardware_num_cpus = 2
-    Int? hardware_memory_GB = 30
-    Int? hardware_max_retries = 0
-    Int? hardware_preemptible_tries = 0
-    # TODO(deflaux) update default later when its published to us.gcr.io/broad-dsde-methods/cytomining
-    String? docker = "gcr.io/terra-solutions-jump-cp-dev/cytomining_jumpcp_recipe:20221018"
+    Int hardware_num_cpus = 1
+    Int hardware_memory_GB = 30
+    Int hardware_max_retries = 0
+    Int hardware_preemptible_tries = 0
   }
 
   # Ensure no trailing slashes
@@ -49,10 +49,10 @@ task profiling {
   String output_directory = sub(output_directory_url, "/+$", "")
 
   # Output filenames
-  String agg_filename = plate_id + ".csv"
-  String aug_filename = plate_id + "_augmented.csv"
-  String norm_filename = plate_id + "_normalized.csv"
-  String norm_negcon_filename = plate_id + "_normalized_negcon.csv"
+  String agg_filename = plate_id + ".csv.gz"
+  String aug_filename = plate_id + "_augmented.csv.gz"
+  String norm_filename = plate_id + "_normalized.csv.gz"
+  String norm_negcon_filename = plate_id + "_normalized_negcon.csv.gz"
 
   command <<<
 
@@ -63,6 +63,7 @@ task profiling {
 
     # Run the monitoring script.
     monitor_script.sh > monitoring.log &
+
 
     function setup_aws_access {
         echo "-----[ Setting up AWS credential for federated authorization. ]-----"
@@ -77,19 +78,30 @@ task profiling {
         echo 'credential_process = "/opt/get_aws_credentials.py" "~{terra_aws_arn}"'  >>  ~/.aws/credentials
     }
 
-    echo "-----[ Checking that the metadata files are TSVs. ]-----"
+
+    echo "-----[ Checking the metadata files. ]-----"
     python <<CODE
     import pandas as pd
-    
-    def assert_tsv(file):
-        df = pd.read_csv(file, sep="\t")
-        print(f"{file} dimensions {df.shape} with columns {df.columns}")
-        if df.shape[1] == 1:
-            raise ValueError(f"{file} has only one column. Check the file format and ensure that it is tab-separated.")
+    from pycytominer.cyto_utils.load import load_platemap
 
-    assert_tsv('~{plate_map_tsv_file}')
-    assert_tsv('~{external_metadata_tsv_file}')
+    def assert_metadata_columns(file, col, msg="Check the value of the 'join_col' parameters for this file."):
+        df = load_platemap(file, add_metadata_id=False)
+        if df.shape[1] < 2:
+            raise ValueError(f"{file} has too few columns. Check the file format and ensure that it is TSV or CSV.")
+        if col not in df.columns:
+            if col.replace("Metadata_", "") not in df.columns: 
+                raise ValueError(f"""{file} has columns {list(df.columns)}.
+                {file} contains neither "{col}" nor its name with suffix "Metadata_" added, if not present.
+                {msg}""")
+
+    assert_metadata_columns(file="~{plate_map_file}", col="~{plate_map_join_col_left}")
+    assert_metadata_columns(file="~{plate_map_file}", col="~{external_metadata_join_col_left}")
+    assert_metadata_columns(file="~{external_metadata_file}", col="~{external_metadata_join_col_right}")
+    # Column used for normalizing to plate for negative controls.
+    assert_metadata_columns(file="~{external_metadata_file}", col="control_type",
+        msg="Ensure that column 'control_type' is present in the external metadata file.")    
     CODE
+
 
     echo "-----[ Checking for write permissions on output bucket. ]-----"
     output_url="~{output_directory}"
@@ -98,11 +110,11 @@ task profiling {
         api_call="https://storage.googleapis.com/storage/v1/b/${bucket_name}/iam/testPermissions?permissions=storage.objects.create"
         set +o xtrace  # Don't log the bearer access token.
         bearer=$(gcloud auth application-default print-access-token)
-        curl "${api_call}" --no-progress-meter --header "Authorization: Bearer $bearer" --header "Accept: application/json" --compressed > response.json
+        curl "${api_call}" --no-progress-meter --header "Authorization: Bearer ${bearer}" --header "Accept: application/json" --compressed > response.json
         set -o xtrace  # Turn tracing back on.
         python_json_parsing="import sys, json; print(str('storage.objects.create' in json.load(sys.stdin).get('permissions', ['none'])).lower())"
         permission=$(cat response.json | python -c "${python_json_parsing}")
-        if [[ $permission == false ]]; then
+        if [[ ${permission} == false ]]; then
            echo "The specified output_url ${output_url} cannot be written to."
            echo "You need storage.objects.create permission on the bucket ${bucket_name}"
            exit 3
@@ -113,6 +125,7 @@ task profiling {
         echo "Bad output_url: '${output_url}' must begin with 'gs://' or 's3://' to be a valid bucket path."
         exit 3
     fi
+
 
     echo "-----[ Localizing data from ~{cellprofiler_analysis_directory}. ]-----"
     start=`date +%s`
@@ -130,10 +143,12 @@ task profiling {
     ls -lh /cromwell_root/data
     ls -lh .
 
+
     echo "-----[ Running cytominer-databse ingest, this takes a long time. ]-----"
     start=`date +%s`
     cytominer-database ingest /cromwell_root/data sqlite:///~{plate_id}.sqlite -c ingest_config.ini --no-munge
     sqlite3 ~{plate_id}.sqlite < indices.sql
+
 
     echo "-----[ Copying sqlite file to ~{output_directory}. ]-----"
     if [[ ~{output_directory} == "s3://"* ]]; then
@@ -145,14 +160,25 @@ task profiling {
     end=`date +%s`
     echo "Total runtime for cytominer-database ingest and copy sqlite to bucket: $((end-start))."
 
+
     echo "-----[ Running pycytominer aggregation step. ]-----"
     python <<CODE
 
     import time
     import pandas as pd
     from pycytominer.cyto_utils.cells import SingleCells
-    from pycytominer.cyto_utils import infer_cp_features
+    from pycytominer.cyto_utils.load import load_platemap
+    from pycytominer.cyto_utils import output
     from pycytominer import normalize, annotate
+    
+    IMAGE_FEATURE_CATEGORIES = ["Intensity", "Granularity", "Texture", "ImageQuality", "Count", "Threshold"]
+    FLOAT_FORMAT = "%.5g"
+    COMPRESSION = "gzip"
+    
+    def fix_join_col_name(col):
+        # Note that a 'Metadata_' prefix is added to all metadata at load time, so also
+        # add this prefix to the join columns if needed.
+        return col if col.startswith('Metadata_') else f'Metadata_{col}'
 
     print("-----[ Creating Single Cell class. ]-----")
     start = time.time()
@@ -160,54 +186,59 @@ task profiling {
         "sqlite:///~{plate_id}.sqlite",
         aggregation_operation="~{aggregation_operation}",
         add_image_features=True,
-        image_feature_categories=["Intensity", "Granularity", "Texture", "ImageQuality", "Count", "Threshold"])
+        image_feature_categories=IMAGE_FEATURE_CATEGORIES)
     print("Time: " + str(time.time() - start))
 
     print("-----[ Aggregating profiles, this takes a long time. ]----- ")
     start = time.time()
     aggregated_df = sc.aggregate_profiles()
-    aggregated_df.to_csv("~{agg_filename}", index=False)
+    output(aggregated_df, "~{agg_filename}", float_format=FLOAT_FORMAT, compression_options=COMPRESSION)
     print("Time: " + str(time.time() - start))
 
     print("-----[ Annotating with metadata. ]-----")
     start = time.time()
-    plate_map_df = pd.read_csv("~{plate_map_tsv_file}", sep="\t")
-    external_metadata_df = pd.read_csv("~{external_metadata_tsv_file}", sep="\t")
+    # The annotate() method calls load_platemap() on the platemap file but not the external metadata file.
+    # Call load_platemap explicitly so that external metadata can be in either CSV or TSV format.
+    external_metadata_df = load_platemap("~{external_metadata_file}")
     annotated_df = annotate(
         profiles=aggregated_df,
-        platemap=plate_map_df,
-        join_on = ~{plate_map_annotate_join_on},
+        platemap="~{plate_map_file}",
+        join_on = [fix_join_col_name("~{plate_map_join_col_left}"), fix_join_col_name("~{plate_map_join_col_right}")],
         external_metadata=external_metadata_df,
-        external_join_left="~{external_metadata_annotate_join_on}",
-        external_join_right="~{external_metadata_annotate_join_on}")
-    annotated_df.to_csv("~{aug_filename}", index=False)
+        external_join_left=fix_join_col_name("~{external_metadata_join_col_left}"),
+        external_join_right=fix_join_col_name("~{external_metadata_join_col_right}"))
+    output(annotated_df, "~{aug_filename}", float_format=FLOAT_FORMAT, compression_options=COMPRESSION)
     print("Time: " + str(time.time() - start))
 
     print("-----[ Normalizing to plate. ]-----")
     start = time.time()
-    normalize(
-        profiles=annotated_df,
-        features="infer",
-        image_features=True,
-        samples="all",
-        method="~{normalize_method}",
-        mad_robustize_epsilon = ~{mad_robustize_epsilon}).to_csv("~{norm_filename}", index=False)
+    output(
+        normalize(
+            profiles=annotated_df,
+            features="infer",
+            image_features=True,
+            samples="all",
+            method="~{normalize_method}",
+            mad_robustize_epsilon = ~{mad_robustize_epsilon}),
+        "~{norm_filename}", float_format=FLOAT_FORMAT, compression_options=COMPRESSION)
     print("Time: " + str(time.time() - start))
 
     print("-----[ Normalizing to plate for negative controls. ]-----")
     start = time.time()
-    normalize(
-        profiles=annotated_df,
-        features="infer",
-        image_features=True,
-        samples="Metadata_control_type == 'negcon'",
-        method="~{normalize_method}",
-        mad_robustize_epsilon = ~{mad_robustize_epsilon}).to_csv("~{norm_negcon_filename}", index=False)
+    output(
+        normalize(
+            profiles=annotated_df,
+            features="infer",
+            image_features=True,
+            samples="Metadata_control_type == 'negcon'",
+            method="~{normalize_method}",
+            mad_robustize_epsilon = ~{mad_robustize_epsilon}),
+        "~{norm_negcon_filename}", float_format=FLOAT_FORMAT, compression_options=COMPRESSION)
     print("Time: " + str(time.time() - start))
     CODE
-
     echo "Completed pycytominer aggregation annotation & normalization."
     ls -lh .
+
 
     echo "-----[ Copying csv outputs to ~{output_directory}. ]----- "
     if [[ ~{output_directory} == "s3://"* ]]; then
@@ -235,9 +266,10 @@ task profiling {
   }
 
   runtime {
-    docker: docker
+    # TODO(deflaux) update default later when its published to us.gcr.io/broad-dsde-methods/cytomining
+    docker: "gcr.io/terra-solutions-jump-cp-dev/cytomining_jumpcp_recipe:20221019"
     disks: "local-disk 500 HDD"
-    memory: "${hardware_memory_GB}G"
+    memory: "~{hardware_memory_GB}G"
     bootDiskSizeGb: 10
     cpu: hardware_num_cpus
     maxRetries: hardware_max_retries
@@ -253,8 +285,10 @@ workflow cytomining {
     String plate_id
 
     # Pycytominer annotation step
-    File plate_map_tsv_file
-    File external_metadata_tsv_file
+    File plate_map_file
+    File external_metadata_file
+    String external_metadata_join_col_left
+    String external_metadata_join_col_right
 
     # Desired location of the outputs
     String output_directory_url
@@ -264,8 +298,10 @@ workflow cytomining {
     input:
         cellprofiler_analysis_directory_url = cellprofiler_analysis_directory_url,
         plate_id = plate_id,
-        plate_map_tsv_file = plate_map_tsv_file,
-        external_metadata_tsv_file = external_metadata_tsv_file,
+        plate_map_file = plate_map_file,
+        external_metadata_file = external_metadata_file,
+        external_metadata_join_col_left = external_metadata_join_col_left,
+        external_metadata_join_col_right = external_metadata_join_col_right,
         output_directory_url = output_directory_url,
   }
 

--- a/pipelines/mining/cytomining.wdl
+++ b/pipelines/mining/cytomining.wdl
@@ -36,6 +36,7 @@ task profiling {
 
     # Hardware-related inputs
     Int? hardware_memory_GB = 30
+    Int? hardware_max_retries = 0
     Int? hardware_preemptible_tries = 0
   }
 
@@ -322,7 +323,7 @@ EOF
     memory: "${hardware_memory_GB}G"
     bootDiskSizeGb: 10
     cpu: 4
-    maxRetries: 2
+    maxRetries: hardware_max_retries
     preemptible: hardware_preemptible_tries
   }
 

--- a/pipelines/mining/cytomining.wdl
+++ b/pipelines/mining/cytomining.wdl
@@ -35,7 +35,7 @@ task profiling {
     String? terra_aws_arn
 
     # Hardware-related inputs
-    Int? hardware_num_cpus = 4
+    Int? hardware_num_cpus = 2
     Int? hardware_memory_GB = 30
     Int? hardware_max_retries = 0
     Int? hardware_preemptible_tries = 0
@@ -89,6 +89,17 @@ task profiling {
     fi
 
     echo "====================================================================="
+
+    echo "Check that the platemap is a TSV ====================="
+    python <<CODE
+    import pandas as pd
+
+    plate_map_df = pd.read_csv('~{plate_map_file}', sep="\t")
+    print(f"Platemap dimensions {plate_map_df.shape} with columns {plate_map_df.columns}")
+    if plate_map_df.shape[1] == 1:
+        raise ValueError(f"Platemap has only one column. Check the file format and ensure that it is tab-separated.")
+    CODE
+
 
     # Send a trace of all fully resolved executed commands to stderr.
     # Note that we enable this _after_ running commands involving credentials, because we do not want to log those values.

--- a/pipelines/mining/cytomining.wdl
+++ b/pipelines/mining/cytomining.wdl
@@ -12,7 +12,7 @@ task profiling {
 
   input {
     # Input files
-    String cellprofiler_analysis_directory_gsurl
+    String cellprofiler_analysis_directory_url
     String plate_id
 
     # Pycytominer aggregation step
@@ -27,16 +27,21 @@ task profiling {
     Float? mad_robustize_epsilon = 0.0
 
     # Desired location of the outputs
-    String output_directory_gsurl
+    String output_directory_url
+
+    # Optional: If the CellProfiler analysis results are in an S3 bucket, this workflow can read the files directly from AWS.
+    # It can also write outputs back to S3, if desired.
+    # To configure this: TODO(deflaux) add instructions
+    String? terra_aws_arn
 
     # Hardware-related inputs
     Int? hardware_memory_GB = 30
-    Int? hardware_preemptible_tries = 2
+    Int? hardware_preemptible_tries = 0
   }
 
   # Ensure no trailing slashes
-  String cellprofiler_analysis_directory = sub(cellprofiler_analysis_directory_gsurl, "/+$", "")
-  String output_directory = sub(output_directory_gsurl, "/+$", "")
+  String cellprofiler_analysis_directory = sub(cellprofiler_analysis_directory_url, "/+$", "")
+  String output_directory = sub(output_directory_url, "/+$", "")
 
   # Output filenames:
   String agg_filename = plate_id + "_aggregated_" + aggregation_operation + ".csv"
@@ -45,37 +50,143 @@ task profiling {
 
   command <<<
 
-    set -e
-
+    set -o errexit
+    set -o pipefail
+    set -o nounset
+    
     # run monitoring script
     monitor_script.sh > monitoring.log &
 
-    # assert write permission on output google bucket
+    # assert write permission on output bucket
     echo "Checking for write permissions on output bucket ====================="
-    gsurl="~{output_directory}"
-    if [[ ${gsurl} != "gs://"* ]]; then
-       echo "Bad gsURL: '${gsurl}' must begin with 'gs://' to be a valid google bucket path."
-       exit 3
+    output_url="~{output_directory}"
+    if [[ ${output_url} == "gs://"* ]]; then
+        bearer=$(gcloud auth application-default print-access-token)
+        bucket_name=$(echo "${output_url#gs://}" | sed 's/\/.*//')
+        api_call="https://storage.googleapis.com/storage/v1/b/${bucket_name}/iam/testPermissions?permissions=storage.objects.create"
+        curl "${api_call}" --header "Authorization: Bearer $bearer" --header "Accept: application/json" --compressed > response.json
+        echo "output_url: ${output_url}"
+        echo "Bucket name: ${bucket_name}"
+        echo "API call: ${api_call}"
+        echo "Response:"
+        cat response.json
+        echo "\n... end of response"
+        python_json_parsing="import sys, json; print(str('storage.objects.create' in json.load(sys.stdin).get('permissions', ['none'])).lower())"
+        permission=$(cat response.json | python -c "${python_json_parsing}")
+        echo "Inferred permission after parsing response JSON: ${permission}"
+        if [[ $permission == false ]]; then
+           echo "The specified output_url ${output_url} cannot be written to."
+           echo "You need storage.objects.create permission on the bucket ${bucket_name}"
+           exit 3
+        fi
+    elif [[ ${output_url} == "s3://"* ]]; then
+        echo "TODO implement the assertion of write permissions on the output S3 bucket, so that this workflow will fail fast."
+    else
+        echo "Bad output_url: '${output_url}' must begin with 'gs://' or 's3://' to be a valid bucket path."
+        exit 3
     fi
-    bearer=$(gcloud auth application-default print-access-token)
-    bucket_name=$(echo "${gsurl#gs://}" | sed 's/\/.*//')
-    api_call="https://storage.googleapis.com/storage/v1/b/${bucket_name}/iam/testPermissions?permissions=storage.objects.create"
-    curl "${api_call}" --header "Authorization: Bearer $bearer" --header "Accept: application/json" --compressed > response.json
-    echo "gsURL: ${gsurl}"
-    echo "Bucket name: ${bucket_name}"
-    echo "API call: ${api_call}"
-    echo "Response:"
-    cat response.json
-    echo "\n... end of response"
-    python_json_parsing="import sys, json; print(str('storage.objects.create' in json.load(sys.stdin).get('permissions', ['none'])).lower())"
-    permission=$(cat response.json | python -c "${python_json_parsing}")
-    echo "Inferred permission after parsing response JSON: ${permission}"
-    if [[ $permission == false ]]; then
-       echo "The specified gsURL ${gsurl} cannot be written to."
-       echo "You need storage.objects.create permission on the bucket ${bucket_name}"
-       exit 3
-    fi
+
     echo "====================================================================="
+
+    # Send a trace of all fully resolved executed commands to stderr.
+    # Note that we enable this _after_ running commands involving credentials, because we do not want to log those values.
+    set -o xtrace
+
+    # TODO eventually move all of this into the cytomining Docker image.
+    function setup_aws_access {
+        ~{if ! defined(terra_aws_arn)
+          then "echo Unable to authenticate to S3. Workflow parameter 'terra_aws_arn' is required for S3 access. ; exit 3"
+          else "echo setting up for AWS access"
+        }
+    
+        if [ ! -f ~/bin/aws ] ; then
+            # Install the AWS CLI
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            unzip -q awscliv2.zip
+            ./aws/install --install-dir $HOME/aws-cli --bin-dir $HOME/bin
+            
+            # Install boto3 which is needed to assume an AWS STS role.
+            pip3 install boto3 requests
+            
+            # Install the federated AWS credential.
+            mkdir -p ~/.aws
+            cat << 'EOF' >  ~/.aws/credentials
+[default]
+credential_process = "/opt/get_creds.py" "~{terra_aws_arn}"
+
+EOF
+
+            # Install the credential-fetching script.
+            mkdir -p /opt
+            cat << 'EOF' >  /opt/get_creds.py
+#!/usr/bin/env python3
+ 
+import argparse
+import boto3
+import getpass
+import json
+import requests
+ 
+META_BASE_URL = 'http://metadata.google.internal/computeMetadata/v1'
+META_HEADERS = {'Metadata-Flavor':  'Google'}
+ 
+def query_metadata(path):
+    response = requests.get(f'{META_BASE_URL}{path}', headers=META_HEADERS)
+    
+    if response.ok:
+        return response.text
+    
+    raise SystemExit(f"Retrieving instance metadata `{path}' failed.")
+    
+def main():
+    
+    parser = argparse.ArgumentParser(description=
+        'Obtain temporary credentials for an AWS Role from GCP VM Service Account')
+    
+    parser.add_argument('role_arn', help= 'AWS ARN corresponding to the role to be assumed.')
+    
+    parser.add_argument('--duration', type=int, default=3600, help=
+        'Duration in seconds, may be up to configured limit (min=900, default=3600)' )
+    
+    args=parser.parse_args()
+    
+    project_name = query_metadata('/project/project-id')
+    vm_name = query_metadata('/instance/name')
+    user_name = getpass.getuser()
+    session_name = f'{project_name},{user_name}'
+    
+    token = query_metadata('/instance/service-accounts/default/identity?audience=gcp&format=standard')
+    
+    sts = boto3.client('sts', aws_access_key_id='', aws_secret_access_key='')
+    
+    try:
+        response = sts.assume_role_with_web_identity(RoleArn=args.role_arn, WebIdentityToken=token, 
+                                                     RoleSessionName=session_name,
+                                                     DurationSeconds=args.duration)
+    except Exception as e:
+        raise SystemExit(e)
+        
+    
+    cred_map = response['Credentials']
+    
+    cred = {
+        'Version': 1,
+        'AccessKeyId': cred_map['AccessKeyId'],
+        'SecretAccessKey': cred_map['SecretAccessKey'],
+        'SessionToken': cred_map['SessionToken'],
+        'Expiration': cred_map['Expiration'].isoformat()
+    }
+    
+    print(json.dumps(cred))
+    
+if __name__ == '__main__':
+    main()
+
+EOF
+
+            chmod a+x /opt/get_creds.py    
+        fi
+    }
 
     # display for log
     echo "Localizing data from ~{cellprofiler_analysis_directory}"
@@ -84,7 +195,12 @@ task profiling {
 
     # localize the data
     mkdir -p /cromwell_root/data
-    gsutil -mq rsync -r -x ".*\.png$" ~{cellprofiler_analysis_directory} /cromwell_root/data
+    if [[ ~{cellprofiler_analysis_directory} == "s3://"* ]]; then
+        setup_aws_access
+        ~/bin/aws s3 cp --recursive --exclude ".*\.png$" --quiet ~{cellprofiler_analysis_directory} /cromwell_root/data
+    else
+        gsutil -mq rsync -r -x ".*\.png$" ~{cellprofiler_analysis_directory} /cromwell_root/data
+    fi
     wget -O ingest_config.ini https://raw.githubusercontent.com/broadinstitute/cytominer_scripts/master/ingest_config.ini
     wget -O indices.sql https://raw.githubusercontent.com/broadinstitute/cytominer_scripts/master/indices.sql
 
@@ -120,8 +236,13 @@ task profiling {
 
     # Copying sqlite
     echo "Copying sqlite file to ~{output_directory}"
-    gsutil cp ~{plate_id}.sqlite ~{output_directory}/
-
+    if [[ ~{output_directory} == "s3://"* ]]; then
+        setup_aws_access
+        ~/bin/aws s3 cp --acl bucket-owner-full-control ~{plate_id}.sqlite ~{output_directory}/
+    else
+        gsutil cp ~{plate_id}.sqlite ~{output_directory}/
+    fi
+    
     # display for log
     end=`date +%s`
     echo $end
@@ -173,10 +294,18 @@ task profiling {
     ls -lh .
 
     echo "Copying csv outputs to ~{output_directory}"
-    gsutil cp ~{agg_filename} ~{output_directory}/
-    gsutil cp ~{aug_filename} ~{output_directory}/
-    gsutil cp ~{norm_filename} ~{output_directory}/
-    gsutil cp monitoring.log ~{output_directory}/
+    if [[ ~{output_directory} == "s3://"* ]]; then
+        setup_aws_access
+        ~/bin/aws s3 cp --acl bucket-owner-full-control ~{agg_filename} ~{output_directory}/
+        ~/bin/aws s3 cp --acl bucket-owner-full-control ~{aug_filename} ~{output_directory}/
+        ~/bin/aws s3 cp --acl bucket-owner-full-control ~{norm_filename} ~{output_directory}/
+        ~/bin/aws s3 cp --acl bucket-owner-full-control monitoring.log ~{output_directory}/
+    else
+        gsutil cp ~{agg_filename} ~{output_directory}/
+        gsutil cp ~{aug_filename} ~{output_directory}/
+        gsutil cp ~{norm_filename} ~{output_directory}/
+        gsutil cp monitoring.log ~{output_directory}/
+    fi
 
     echo "Done."
 
@@ -202,22 +331,22 @@ task profiling {
 
 workflow cytomining {
   input {
-    String cellprofiler_analysis_directory_gsurl
+    String cellprofiler_analysis_directory_url
     String plate_id
 
     # Pycytominer annotation step
     File plate_map_file
 
     # Desired location of the outputs
-    String output_directory_gsurl
+    String output_directory_url
   }
 
   call profiling {
     input:
-        cellprofiler_analysis_directory_gsurl = cellprofiler_analysis_directory_gsurl,
+        cellprofiler_analysis_directory_url = cellprofiler_analysis_directory_url,
         plate_id = plate_id,
         plate_map_file = plate_map_file,
-        output_directory_gsurl = output_directory_gsurl,
+        output_directory_url = output_directory_url,
   }
 
   output {

--- a/pipelines/mining/cytomining.wdl
+++ b/pipelines/mining/cytomining.wdl
@@ -257,36 +257,36 @@ EOF
     echo "Running pycytominer aggregation step"
     python <<CODE
 
-    import time
-    import pandas as pd
-    from pycytominer.cyto_utils.cells import SingleCells
-    from pycytominer.cyto_utils import infer_cp_features
-    from pycytominer import normalize, annotate
+import time
+import pandas as pd
+from pycytominer.cyto_utils.cells import SingleCells
+from pycytominer.cyto_utils import infer_cp_features
+from pycytominer import normalize, annotate
 
-    print("Creating Single Cell class... ")
-    start = time.time()
-    sc = SingleCells('sqlite:///~{plate_id}.sqlite',aggregation_operation='~{aggregation_operation}')
-    print("Time: " + str(time.time() - start))
+print("Creating Single Cell class... ")
+start = time.time()
+sc = SingleCells('sqlite:///~{plate_id}.sqlite',aggregation_operation='~{aggregation_operation}')
+print("Time: " + str(time.time() - start))
 
-    print("Aggregating profiles... ")
-    start = time.time()
-    aggregated_df = sc.aggregate_profiles()
-    aggregated_df.to_csv('~{agg_filename}', index=False)
-    print("Time: " + str(time.time() - start))
+print("Aggregating profiles... ")
+start = time.time()
+aggregated_df = sc.aggregate_profiles()
+aggregated_df.to_csv('~{agg_filename}', index=False)
+print("Time: " + str(time.time() - start))
 
-    print("Annotating with metadata... ")
-    start = time.time()
-    plate_map_df = pd.read_csv('~{plate_map_file}', sep="\t")
-    annotated_df = annotate(aggregated_df, plate_map_df, join_on = ~{annotate_join_on})
-    annotated_df.to_csv('~{aug_filename}',index=False)
-    print("Time: " + str(time.time() - start))
+print("Annotating with metadata... ")
+start = time.time()
+plate_map_df = pd.read_csv('~{plate_map_file}', sep="\t")
+annotated_df = annotate(aggregated_df, plate_map_df, join_on = ~{annotate_join_on})
+annotated_df.to_csv('~{aug_filename}',index=False)
+print("Time: " + str(time.time() - start))
 
-    print("Normalizing to plate.. ")
-    start = time.time()
-    normalize(annotated_df, method='~{normalize_method}', mad_robustize_epsilon = ~{mad_robustize_epsilon}).to_csv('~{norm_filename}',index=False)
-    print("Time: " + str(time.time() - start))
+print("Normalizing to plate.. ")
+start = time.time()
+normalize(annotated_df, method='~{normalize_method}', mad_robustize_epsilon = ~{mad_robustize_epsilon}).to_csv('~{norm_filename}',index=False)
+print("Time: " + str(time.time() - start))
 
-    CODE
+CODE
 
     # display for log
     echo " "

--- a/pipelines/mining/cytomining.wdl
+++ b/pipelines/mining/cytomining.wdl
@@ -40,8 +40,8 @@ task profiling {
     Int? hardware_memory_GB = 30
     Int? hardware_max_retries = 0
     Int? hardware_preemptible_tries = 0
-    # TODO(deflaux) default to Docker image with JUMP/CP profiling recipe later when its published to us.gcr.io/broad-dsde-methods/cytomining
-    String docker
+    # TODO(deflaux) update default later when its published to us.gcr.io/broad-dsde-methods/cytomining
+    String? docker = "gcr.io/terra-solutions-jump-cp-dev/cytomining_jumpcp_recipe:20221018"
   }
 
   # Ensure no trailing slashes
@@ -156,10 +156,11 @@ task profiling {
 
     print("-----[ Creating Single Cell class. ]-----")
     start = time.time()
-    sc = SingleCells("sqlite:///~{plate_id}.sqlite",
-                     aggregation_operation="~{aggregation_operation}",
-                     add_image_features=True,
-                     image_feature_categories=["Intensity", "Granularity", "Texture", "ImageQuality", "Count", "Threshold"])
+    sc = SingleCells(
+        "sqlite:///~{plate_id}.sqlite",
+        aggregation_operation="~{aggregation_operation}",
+        add_image_features=True,
+        image_feature_categories=["Intensity", "Granularity", "Texture", "ImageQuality", "Count", "Threshold"])
     print("Time: " + str(time.time() - start))
 
     print("-----[ Aggregating profiles, this takes a long time. ]----- ")

--- a/pipelines/mining/get_aws_credentials.py
+++ b/pipelines/mining/get_aws_credentials.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import argparse
+import boto3
+import getpass
+import json
+import requests
+
+META_BASE_URL = 'http://metadata.google.internal/computeMetadata/v1'
+META_HEADERS = {'Metadata-Flavor':  'Google'}
+
+def query_metadata(path):
+    response = requests.get(f'{META_BASE_URL}{path}', headers=META_HEADERS)
+
+    if response.ok:
+        return response.text
+
+    raise SystemExit(f"Retrieving instance metadata `{path}' failed.")
+
+def main():
+
+    parser = argparse.ArgumentParser(description=
+        'Obtain temporary credentials for an AWS Role from GCP VM Service Account')
+
+    parser.add_argument('role_arn', help= 'AWS ARN corresponding to the role to be assumed.')
+
+    parser.add_argument('--duration', type=int, default=3600, help=
+        'Duration in seconds, may be up to configured limit (min=900, default=3600)' )
+
+    args=parser.parse_args()
+
+    project_name = query_metadata('/project/project-id')
+    vm_name = query_metadata('/instance/name')
+    user_name = getpass.getuser()
+    session_name = f'{project_name},{user_name}'
+
+    token = query_metadata('/instance/service-accounts/default/identity?audience=gcp&format=standard')
+
+    sts = boto3.client('sts', aws_access_key_id='', aws_secret_access_key='')
+
+    try:
+        response = sts.assume_role_with_web_identity(RoleArn=args.role_arn, WebIdentityToken=token, 
+                                                     RoleSessionName=session_name,
+                                                     DurationSeconds=args.duration)
+    except Exception as e:
+        raise SystemExit(e)
+
+    cred_map = response['Credentials']
+
+    cred = {
+        'Version': 1,
+        'AccessKeyId': cred_map['AccessKeyId'],
+        'SecretAccessKey': cred_map['SecretAccessKey'],
+        'SessionToken': cred_map['SessionToken'],
+        'Expiration': cred_map['Expiration'].isoformat()
+    }
+
+    print(json.dumps(cred))
+
+if __name__ == '__main__':
+    main()

--- a/tests/cellpainting_workflow.wdl
+++ b/tests/cellpainting_workflow.wdl
@@ -55,8 +55,10 @@ workflow cellpainting_workflow {
     #### arguments for cytomining ####
     ####################################
     # Metadata for annotation step
-    File plate_map_tsv_file
-    File external_metadata_tsv_file
+    File plate_map_file
+    File external_metadata_file
+    String external_metadata_join_col_left
+    String external_metadata_join_col_right
     # Final output with SQlite and .csv aggregated profiles
     String mining_directory_gsurl
 
@@ -104,8 +106,10 @@ workflow cellpainting_workflow {
     input:
       cellprofiler_analysis_directory_url = cpd_analysis.analysis_output_directory,
       plate_id = plate_id,
-      plate_map_tsv_file = plate_map_tsv_file,
-      external_metadata_tsv_file = external_metadata_tsv_file,
+      plate_map_file = plate_map_file,
+      external_metadata_file = external_metadata_file,
+      external_metadata_join_col_left = external_metadata_join_col_left,
+      external_metadata_join_col_right = external_metadata_join_col_right,
       output_directory_url = mining_directory_gsurl,
   }
 

--- a/tests/cellpainting_workflow.wdl
+++ b/tests/cellpainting_workflow.wdl
@@ -55,7 +55,8 @@ workflow cellpainting_workflow {
     #### arguments for cytomining ####
     ####################################
     # Metadata for annotation step
-    File plate_map_file
+    File plate_map_tsv_file
+    File external_metadata_tsv_file
     # Final output with SQlite and .csv aggregated profiles
     String mining_directory_gsurl
 
@@ -101,10 +102,11 @@ workflow cellpainting_workflow {
   # Run cytomining
   call cytomining_workflow.cytomining as cytomining {
     input:
-      cellprofiler_analysis_directory_gsurl = cpd_analysis.analysis_output_directory,
+      cellprofiler_analysis_directory_url = cpd_analysis.analysis_output_directory,
       plate_id = plate_id,
-      plate_map_file = plate_map_file,
-      output_directory_gsurl = mining_directory_gsurl,
+      plate_map_tsv_file = plate_map_tsv_file,
+      external_metadata_tsv_file = external_metadata_tsv_file,
+      output_directory_url = mining_directory_gsurl,
   }
 
 }


### PR DESCRIPTION
@carmendv please let me know if this these changes are generally useful or if it should be a distinct new workflow. I'll update the README accordingly after you let me know.

Summary of changes:
* Add AWS federated auth so that inputs/outputs can come from/to S3 in addition to GCS.
* add bucket writability check for S3 buckets
* use `pycytominer@36241269c4293c24484986568ca16b2d7eb9e808` instead of `pycytominer==0.2.0`
* also optionally annotate with external metadata
* allow metadata in both CSV and TSV format
* allow join keys still work even if they are missing the `Metadata_` prefix.
* validate metadata early in the workflow to fail fast if files are not in the correct format or the join keys are not present
* add additional image features for intensity
* add an additional normalization step over a subset of samples, default to JUMP/CP 'control_type' column for subset 'negcon'
* use expected JUMP/CP-specific output filenames
* gzip output files
* write floats with a max of 5 digits of precision to output files
* default to 1 CPU on a regular VM (not preemptible) and do no retries
* use set -o xtrace to replace the need for many debugging echo statements in the WDL