### PR TITLE
Make all workflows fail fast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
+# Mac
+.DS_Store
+
 # Cromwell / womtool generated files to submit jobs
 .dot
 .inputs
 .input
 .png
 .json
+.zip
+.pdf
 
 # History files
 .Rhistory

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# Cromwell / womtool generated files to submit jobs
+.dot
+.inputs
+.input
+.png
+.json
+
 # History files
 .Rhistory
 .Rapp.history

--- a/pipelines/cellpainting/cp_illumination_pipeline.wdl
+++ b/pipelines/cellpainting/cp_illumination_pipeline.wdl
@@ -65,7 +65,7 @@ workflow cp_illumination_pipeline {
 
   output {
     String images_output_directory = images_directory
-    String? illum_output_directory = rsync_illum.output_directory
+    String illum_output_directory = select_first([rsync_illum.output_directory, ""])
   }
 
 }

--- a/pipelines/cellpainting/cp_illumination_pipeline.wdl
+++ b/pipelines/cellpainting/cp_illumination_pipeline.wdl
@@ -65,7 +65,7 @@ workflow cp_illumination_pipeline {
 
   output {
     String images_output_directory = images_directory
-    String illum_output_directory = rsync_illum.output_directory
+    String? illum_output_directory = rsync_illum.output_directory
   }
 
 }

--- a/pipelines/cellpainting/cpd_analysis_pipeline.wdl
+++ b/pipelines/cellpainting/cpd_analysis_pipeline.wdl
@@ -33,36 +33,48 @@ workflow cpd_analysis_pipeline {
   String output_directory = sub(output_directory_gsurl, "/+$", "")
   String illum_directory = sub(illum_directory_gsurl, "/+$", "")
 
-  # Create an index to scatter
-  call util.scatter_index as idx {
+  # check write permission on output bucket
+  call util.gcloud_is_bucket_writable as permission_check {
     input:
-      load_data_csv= load_data_csv,
-      splitby_metadata = splitby_metadata,
+      gsurls=[output_directory],
   }
 
-  # Run CellProfiler pipeline scattered
-  scatter(index in idx.value) {
-    call util.splitto_scatter as sp {
+  # run the compute only if output bucket is writable
+  Boolean is_bucket_writable = permission_check.is_bucket_writable
+  if (is_bucket_writable) {
+
+    # Create an index to scatter
+    call util.scatter_index as idx {
       input:
-        image_directory =  images_directory,
-        illum_directory = illum_directory,
-        load_data_csv = load_data_csv,
+        load_data_csv= load_data_csv,
         splitby_metadata = splitby_metadata,
-        index = index,
     }
 
-    call util.cellprofiler_pipeline_task as cellprofiler {
-      input:
-        all_images_files = sp.array_output,
-        cppipe_file =cppipe_file,
-        load_data_csv = sp.output_tiny_csv,
+    # Run CellProfiler pipeline scattered
+    scatter(index in idx.value) {
+      call util.splitto_scatter as sp {
+        input:
+          image_directory =  images_directory,
+          illum_directory = illum_directory,
+          load_data_csv = load_data_csv,
+          splitby_metadata = splitby_metadata,
+          index = index,
+      }
+
+      call util.cellprofiler_pipeline_task as cellprofiler {
+        input:
+          all_images_files = sp.array_output,
+          cppipe_file =cppipe_file,
+          load_data_csv = sp.output_tiny_csv,
+      }
+
+      call util.extract_and_gsutil_rsync {
+        input:
+          tarball=cellprofiler.tarball,
+          destination_gsurl=output_directory + "/" + index,
+      }
     }
 
-    call util.extract_and_gsutil_rsync {
-      input:
-        tarball=cellprofiler.tarball,
-        destination_gsurl=output_directory + "/" + index,
-    }
   }
 
   output {

--- a/pipelines/cellpainting/cpd_max_projection_pipeline.wdl
+++ b/pipelines/cellpainting/cpd_max_projection_pipeline.wdl
@@ -101,8 +101,8 @@ workflow cpd_max_projection_distributed {
 
   output {
     String images_projected_directory_gsurl = output_directory
-    File load_data_csv = select_first([script.load_data_csv, stderr()])
-    File load_data_with_illum_csv = select_first([script.load_data_with_illum_csv, stderr()])
+    File load_data_csv = select_first([script.load_data_csv, permission_check.log])
+    File load_data_with_illum_csv = select_first([script.load_data_with_illum_csv, permission_check.log])
   }
 
 }

--- a/pipelines/cellpainting/cpd_max_projection_pipeline.wdl
+++ b/pipelines/cellpainting/cpd_max_projection_pipeline.wdl
@@ -101,8 +101,8 @@ workflow cpd_max_projection_distributed {
 
   output {
     String images_projected_directory_gsurl = output_directory
-    File? load_data_csv = script.load_data_csv
-    File? load_data_with_illum_csv = script.load_data_with_illum_csv
+    File load_data_csv = select_first([script.load_data_csv, stderr()])
+    File load_data_with_illum_csv = select_first([script.load_data_with_illum_csv, stderr()])
   }
 
 }

--- a/pipelines/cellpainting/cpd_max_projection_pipeline.wdl
+++ b/pipelines/cellpainting/cpd_max_projection_pipeline.wdl
@@ -34,63 +34,75 @@ workflow cpd_max_projection_distributed {
   String output_directory = sub(output_images_directory_gsurl, "/+$", "")
   String output_load_data_directory = sub(output_load_data_directory_gsurl, "/+$", "")
 
-  # Create an index to scatter
-  call util.scatter_index as idx {
+  # check write permission on output bucket
+  call util.gcloud_is_bucket_writable as permission_check {
     input:
-      load_data_csv= load_data,
-      splitby_metadata = splitby_metadata,
+      gsurls=[output_directory, output_load_data_directory],
   }
 
-  # Run CellProfiler pipeline scattered
-  scatter(index in idx.value) {
-    call util.splitto_scatter as sp {
+  # run the compute only if output bucket is writable
+  Boolean is_bucket_writable = permission_check.is_bucket_writable
+  if (is_bucket_writable) {
+
+    # Create an index to scatter
+    call util.scatter_index as idx {
       input:
-        image_directory =  images_directory,
-        illum_directory = "/illum",  # default
-        load_data_csv = load_data,
+        load_data_csv= load_data,
         splitby_metadata = splitby_metadata,
-        index = index,
     }
 
-    call util.cellprofiler_pipeline_task as cellprofiler {
+    # Run CellProfiler pipeline scattered
+    scatter(index in idx.value) {
+      call util.splitto_scatter as sp {
+        input:
+          image_directory =  images_directory,
+          illum_directory = "/illum",  # default
+          load_data_csv = load_data,
+          splitby_metadata = splitby_metadata,
+          index = index,
+      }
+
+      call util.cellprofiler_pipeline_task as cellprofiler {
+        input:
+          all_images_files = sp.array_output,
+          cppipe_file = cppipe_file,
+          load_data_csv = sp.output_tiny_csv,
+      }
+
+      call util.extract_and_gsutil_rsync {
+        input:
+          tarball=cellprofiler.tarball,
+          destination_gsurl=output_images_directory_gsurl,
+      }
+    }
+
+    # Create new load_data/load_data_with_illum csv files with the new projected images
+    call util.filter_csv as script {
       input:
-        all_images_files = sp.array_output,
-        cppipe_file = cppipe_file,
-        load_data_csv = sp.output_tiny_csv,
+        full_load_data_csv= load_data,
+        full_load_data_with_illum_csv= load_data_with_illum,
     }
 
-    call util.extract_and_gsutil_rsync {
+    # Save load_data.csv file
+    call util.gsutil_delocalize as save_load_data {
       input:
-        tarball=cellprofiler.tarball,
-        destination_gsurl=output_images_directory_gsurl,
+        file=script.load_data_csv,
+        destination_gsurl=output_load_data_directory,
     }
-  }
 
-  # Create new load_data/load_data_with_illum csv files with the new projected images
-  call util.filter_csv as script {
-    input:
-      full_load_data_csv= load_data,
-      full_load_data_with_illum_csv= load_data_with_illum,
-  }
+    # Save load_data_will_illum.csv file
+    call util.gsutil_delocalize as save_illum {
+      input:
+        file=script.load_data_with_illum_csv,
+        destination_gsurl=output_load_data_directory,
+    }
 
-  # Save load_data.csv file
-  call util.gsutil_delocalize as save_load_data {
-    input:
-      file=script.load_data_csv,
-      destination_gsurl=output_load_data_directory,
-  }
-
-  # Save load_data_will_illum.csv file
-  call util.gsutil_delocalize as save_illum {
-    input:
-      file=script.load_data_with_illum_csv,
-      destination_gsurl=output_load_data_directory,
   }
 
   output {
-    String images_projected_directory_gsurl = output_images_directory_gsurl
-    File load_data_csv = script.load_data_csv
-    File load_data_with_illum_csv = script.load_data_with_illum_csv
+    String images_projected_directory_gsurl = output_directory
+    File? load_data_csv = script.load_data_csv
+    File? load_data_with_illum_csv = script.load_data_with_illum_csv
   }
 
 }

--- a/pipelines/cellpainting/create_load_data.wdl
+++ b/pipelines/cellpainting/create_load_data.wdl
@@ -75,8 +75,8 @@ workflow create_load_data {
   }
 
   output {
-    File? load_data_csv = script.load_data_csv
-    File? load_data_with_illum_csv = script.load_data_with_illum_csv
+    File load_data_csv = select_first([script.load_data_csv, stderr()])
+    File load_data_with_illum_csv = select_first([script.load_data_with_illum_csv, stderr()])
   }
 
 }

--- a/pipelines/cellpainting/create_load_data.wdl
+++ b/pipelines/cellpainting/create_load_data.wdl
@@ -75,8 +75,8 @@ workflow create_load_data {
   }
 
   output {
-    File load_data_csv = select_first([script.load_data_csv, stderr()])
-    File load_data_with_illum_csv = select_first([script.load_data_with_illum_csv, stderr()])
+    File load_data_csv = select_first([script.load_data_csv, permission_check.log])
+    File load_data_with_illum_csv = select_first([script.load_data_with_illum_csv, permission_check.log])
   }
 
 }

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -44,8 +44,7 @@ workflow cellprofiler_pipeline {
         gsurls=[output_directory],
     }
   }
-  Boolean? permission = permission_check.is_bucket_writable
-  Boolean no_permission_error = if defined(permission) then permission else true
+  Boolean no_permission_error = select_first([permission_check.is_bucket_writable, true])
   if (no_permission_error) {
 
     # Define the input files, so that we use Cromwell's automatic file localization

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -127,8 +127,8 @@ workflow cellprofiler_pipeline {
   }
 
   output {
-    Array[File] cellprofiler_tarballs = select_first([output_tarball_array, [stderr()]])
-    Array[File] cellprofiler_logs = select_first([output_log_array, [stderr()]])
+    Array[File] cellprofiler_tarballs = select_first([output_tarball_array])
+    Array[File] cellprofiler_logs = select_first([output_log_array])
     String output_path = output_directory
   }
 

--- a/pipelines/cellprofiler/cellprofiler_pipeline.wdl
+++ b/pipelines/cellprofiler/cellprofiler_pipeline.wdl
@@ -36,86 +36,98 @@ workflow cellprofiler_pipeline {
   String input_directory = sub(input_directory_gsurl, "/+$", "")
   String output_directory = sub(output_directory_gsurl, "/+$", "")
 
-  # Define the input files, so that we use Cromwell's automatic file localization
-  call util.gsutil_ls_to_file as directory {
+  # check write permission on output bucket
+  call util.gcloud_is_bucket_writable as permission_check {
     input:
-      directory_gsurl=input_directory,
-      file_extension=file_extension,
+      gsurls=[output_directory],
   }
 
-  # The single VM workflow
-  if (!do_scatter) {
+  # run the compute only if output bucket is writable
+  Boolean is_bucket_writable = permission_check.is_bucket_writable
+  if (is_bucket_writable) {
 
-    # Run CellProfiler pipeline
-    call util.cellprofiler_pipeline_task as cellprofiler {
+    # Define the input files, so that we use Cromwell's automatic file localization
+    call util.gsutil_ls_to_file as directory {
       input:
-        all_images_files=read_lines(directory.out),
-        load_data_csv=load_data_csv,
-        cppipe_file=cppipe_file,
+        directory_gsurl=input_directory,
+        file_extension=file_extension,
     }
 
-    # Optionally delocalize outputs
-    if (output_directory_gsurl != "") {
-      call util.extract_and_gsutil_rsync as extract_and_gsutil_rsync {
+    # The single VM workflow
+    if (!do_scatter) {
+
+      # Run CellProfiler pipeline
+      call util.cellprofiler_pipeline_task as cellprofiler {
         input:
-          tarball=cellprofiler.tarball,
-          destination_gsurl=output_directory,
-      }
-    }
-    Array[String]? output_tarball_array_single = [cellprofiler.tarball]
-    Array[String]? output_log_array_single = [cellprofiler.log]
-
-  }
-
-  # The distributed workflow, running in parallel on many VMs
-  if (do_scatter) {
-
-    # Create an index to scatter
-    call util.scatter_index as idx {
-      input:
-        load_data_csv=load_data_csv,
-        splitby_metadata=splitby_metadata,
-    }
-
-    # Run CellProfiler pipeline scattered
-    scatter(index in idx.value) {
-
-      call util.splitto_scatter as sp {
-        input:
-          image_directory=input_directory,
-          illum_directory=illum_directory,
+          all_images_files=read_lines(directory.out),
           load_data_csv=load_data_csv,
-          splitby_metadata=splitby_metadata,
-          index=index,
-      }
-
-      call util.cellprofiler_pipeline_task as cellprofiler_scattered {
-        input:
-          all_images_files=sp.array_output,
-          load_data_csv=sp.output_tiny_csv,
           cppipe_file=cppipe_file,
       }
 
       # Optionally delocalize outputs
       if (output_directory_gsurl != "") {
-        call util.extract_and_gsutil_rsync as extract_and_gsutil_rsync_scattered {
+        call util.extract_and_gsutil_rsync as extract_and_gsutil_rsync {
           input:
-            tarball=cellprofiler_scattered.tarball,
-            destination_gsurl=output_directory + "/" + index,
+            tarball=cellprofiler.tarball,
+            destination_gsurl=output_directory,
         }
       }
+      Array[String]? output_tarball_array_single = [cellprofiler.tarball]
+      Array[String]? output_log_array_single = [cellprofiler.log]
 
     }
-    Array[String]? output_tarball_array_scattered = cellprofiler_scattered.tarball
-    Array[String]? output_log_array_scattered = cellprofiler_scattered.log
+
+    # The distributed workflow, running in parallel on many VMs
+    if (do_scatter) {
+
+      # Create an index to scatter
+      call util.scatter_index as idx {
+        input:
+          load_data_csv=load_data_csv,
+          splitby_metadata=splitby_metadata,
+      }
+
+      # Run CellProfiler pipeline scattered
+      scatter(index in idx.value) {
+
+        call util.splitto_scatter as sp {
+          input:
+            image_directory=input_directory,
+            illum_directory=illum_directory,
+            load_data_csv=load_data_csv,
+            splitby_metadata=splitby_metadata,
+            index=index,
+        }
+
+        call util.cellprofiler_pipeline_task as cellprofiler_scattered {
+          input:
+            all_images_files=sp.array_output,
+            load_data_csv=sp.output_tiny_csv,
+            cppipe_file=cppipe_file,
+        }
+
+        # Optionally delocalize outputs
+        if (output_directory_gsurl != "") {
+          call util.extract_and_gsutil_rsync as extract_and_gsutil_rsync_scattered {
+            input:
+              tarball=cellprofiler_scattered.tarball,
+              destination_gsurl=output_directory + "/" + index,
+          }
+        }
+
+      }
+      Array[String]? output_tarball_array_scattered = cellprofiler_scattered.tarball
+      Array[String]? output_log_array_scattered = cellprofiler_scattered.log
+
+    }
+    Array[String] output_tarball_array = select_first([output_tarball_array_single, output_tarball_array_scattered])
+    Array[String] output_log_array = select_first([output_log_array_single, output_log_array_scattered])
 
   }
-  Array[String] output_tarball_array = select_first([output_tarball_array_single, output_tarball_array_scattered])
-  Array[String] output_log_array = select_first([output_log_array_single, output_log_array_scattered])
 
   output {
-    Array[File] cellprofiler_tarballs = output_tarball_array
-    Array[File] cellprofiler_logs = output_log_array
+    Array[File] cellprofiler_tarballs = select_first([output_tarball_array, [stderr()]])
+    Array[File] cellprofiler_logs = select_first([output_log_array, [stderr()]])
     String output_path = output_directory
   }
 

--- a/pipelines/mining/cytomining.wdl
+++ b/pipelines/mining/cytomining.wdl
@@ -208,8 +208,8 @@ workflow cytomining {
   }
 
   output {
-    File monitoring_log = profiling.monitoring_log
-    File log = profiling.log
+    File? monitoring_log = profiling.monitoring_log
+    File? log = profiling.log
   }
 
 }

--- a/pipelines/mining/cytomining.wdl
+++ b/pipelines/mining/cytomining.wdl
@@ -208,8 +208,8 @@ workflow cytomining {
   }
 
   output {
-    File? monitoring_log = profiling.monitoring_log
-    File? log = profiling.log
+    File monitoring_log = select_first([profiling.monitoring_log, stderr()])
+    File log = select_first([profiling.log, stderr()])
   }
 
 }

--- a/pipelines/mining/cytomining.wdl
+++ b/pipelines/mining/cytomining.wdl
@@ -1,5 +1,7 @@
 version 1.0
 
+import "../../utils/cellprofiler_distributed_utils.wdl" as util
+
 ## Copyright Broad Institute, 2021
 ##
 ## LICENSING :
@@ -49,33 +51,6 @@ task profiling {
 
     # run monitoring script
     monitor_script.sh > monitoring.log &
-
-    # assert write permission on output google bucket
-    echo "Checking for write permissions on output bucket ====================="
-    gsurl="~{output_directory}"
-    if [[ ${gsurl} != "gs://"* ]]; then
-       echo "Bad gsURL: '${gsurl}' must begin with 'gs://' to be a valid google bucket path."
-       exit 3
-    fi
-    bearer=$(gcloud auth application-default print-access-token)
-    bucket_name=$(echo "${gsurl#gs://}" | sed 's/\/.*//')
-    api_call="https://storage.googleapis.com/storage/v1/b/${bucket_name}/iam/testPermissions?permissions=storage.objects.create"
-    curl "${api_call}" --header "Authorization: Bearer $bearer" --header "Accept: application/json" --compressed > response.json
-    echo "gsURL: ${gsurl}"
-    echo "Bucket name: ${bucket_name}"
-    echo "API call: ${api_call}"
-    echo "Response:"
-    cat response.json
-    echo "\n... end of response"
-    python_json_parsing="import sys, json; print(str('storage.objects.create' in json.load(sys.stdin).get('permissions', ['none'])).lower())"
-    permission=$(cat response.json | python -c "${python_json_parsing}")
-    echo "Inferred permission after parsing response JSON: ${permission}"
-    if [[ $permission == false ]]; then
-       echo "The specified gsURL ${gsurl} cannot be written to."
-       echo "You need storage.objects.create permission on the bucket ${bucket_name}"
-       exit 3
-    fi
-    echo "====================================================================="
 
     # display for log
     echo "Localizing data from ~{cellprofiler_analysis_directory}"
@@ -212,12 +187,24 @@ workflow cytomining {
     String output_directory_gsurl
   }
 
-  call profiling {
+  # check write permission on output bucket
+  call util.gcloud_is_bucket_writable as permission_check {
     input:
+      gsurls=[output_directory_gsurl],
+  }
+
+  # run the compute only if output bucket is writable
+  Boolean is_bucket_writable = permission_check.is_bucket_writable
+  if (is_bucket_writable) {
+
+    call profiling {
+      input:
         cellprofiler_analysis_directory_gsurl = cellprofiler_analysis_directory_gsurl,
         plate_id = plate_id,
         plate_map_file = plate_map_file,
         output_directory_gsurl = output_directory_gsurl,
+    }
+
   }
 
   output {

--- a/pipelines/mining/cytomining.wdl
+++ b/pipelines/mining/cytomining.wdl
@@ -208,8 +208,8 @@ workflow cytomining {
   }
 
   output {
-    File monitoring_log = select_first([profiling.monitoring_log, stderr()])
-    File log = select_first([profiling.log, stderr()])
+    File monitoring_log = select_first([profiling.monitoring_log, permission_check.log])
+    File log = select_first([profiling.log, permission_check.log])
   }
 
 }

--- a/utils/cellprofiler_distributed_utils.wdl
+++ b/utils/cellprofiler_distributed_utils.wdl
@@ -460,6 +460,9 @@ task gcloud_is_bucket_writable {
     set -e
     bearer=$(gcloud auth application-default print-access-token)
 
+    # initially assume we do not have permission
+    echo false > ~{result_filename}
+
     for gsurl in ~{sep=" " gsurls}; do
 
       # check write permission on output google bucket
@@ -489,7 +492,9 @@ task gcloud_is_bucket_writable {
 
     done
 
+    # if we made it here without exiting due to error, then we have permission
     echo true > ~{result_filename}
+    exit 0
   >>>
 
   output {

--- a/utils/cellprofiler_distributed_utils.wdl
+++ b/utils/cellprofiler_distributed_utils.wdl
@@ -499,6 +499,7 @@ task gcloud_is_bucket_writable {
 
   output {
     Boolean is_bucket_writable = read_boolean(result_filename)
+    File log = stdout()
   }
 
   runtime {


### PR DESCRIPTION
Closes #23 and implements "fail fast" for all workflows that specify an output bucket.

The logic follows the discussion in #23 and uses a utility task to ascertain write permission the output bucket.  The subsequent task(s) only run (using an explicit if-statement) if the permissions check is successful.

**Desired outcomes to test for:**

- [x] The workflow in Terra should succeed if permissions exist
- [x] The whole workflow in Terra should have "Failed" status if the permission checking task fails
- [x] The subsequent compute should not occur if the permission checking task fails
- [x] There should be a clear error message that the workflow failed because the permission checking task failed, and there should be a descriptive error explaining exactly why the failure happened.