### PR TITLE
Enable cytomining.wdl to run on a local machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Mac
 .DS_Store
 
+# Data files
+data/*
+
 # Cromwell / womtool generated files to submit jobs
 .dot
 .inputs

--- a/pipelines/mining/README.md
+++ b/pipelines/mining/README.md
@@ -147,6 +147,7 @@ For comprehensive overview, see the following full example:
 ```console
 (cromwell) $ ls
 data/
+cytomining.wdl
 inputs.json
 options.json
 
@@ -206,22 +207,32 @@ A02/outlines/A02_s1--cell_outlines.png
 
 (cromwell) $ ls
 data/
+cytomining.wdl
+files.tar.gz
 inputs.json
 options.json
-files.tar.gz
 
 (cromwell) $ cromwell run cytomining.wdl -i inputs.json -o options.json
 <LOTS OF LOGS! ... wait until the task completes ...>
 
 (cromwell) $ ls
+cromwell-executions/
+cromwell-workflow-logs/
 cromwell_outputs/
 data/
+cytomining.wdl
+files.tar.gz
 inputs.json
 options.json
-files.tar.gz
 
 (cromwell) $ ls cromwell_outputs/
-
+BR00116991.sqlite
+BR00116991_annotated_mean.csv
+BR00116991_normalized_mean.csv
+monitoring.log
+stdout
+call_logs/
+wf_logs/
 
 (cromwell) $ rm -r cromwell-*
 

--- a/pipelines/mining/README.md
+++ b/pipelines/mining/README.md
@@ -26,3 +26,206 @@ Workflow `cytomining_jumpcp.wdl` is similar to `cytomining.wdl` but has the foll
     * Validate metadata early in the workflow to fail fast if files are not in the correct format or the join keys are not present
     * Default to 1 CPU on a regular VM (not preemptible) and do no retries
     * Use set -o xtrace to replace the need for many debugging echo statements in the WDL
+
+### Running locally
+ 
+This workflow has been designed to be run locally on your own machine via `comwell run` for those interested.
+The local run will recapitulate the same thing the cloud workflow does, so it is useful for testing.
+
+Ensure you have `cromwell` installed.
+We recommend using `conda` to install cromwell in its own conda environment, as in
+```console
+$ conda create -n cromwell python=3.8
+$ conda activate cromwell
+(cromwell) $ conda install -c bioconda cromwell
+```
+
+Running locally amounts to running the following command:
+```console
+(cromwell) $ cromwell run cytomining.wdl -i inputs.json -o options.json
+```
+where `cytomining.wdl` is the path to your local copy of this WDL.
+Example `inputs.json` and `options.json` are included in the repo, and are shown below.
+
+Inputs JSON file:
+```json
+{
+  "cytomining.cellprofiler_analysis_tarball": "files.tar.gz",
+  "cytomining.plate_map_file": "JUMP-Target-1_compound_platemap.tsv",
+  "cytomining.plate_id": "BR00116991"
+}
+```
+Each input, `plate_map_file`, `plate_id`, and `cellprofiler_analysis_tarball` is specific to your dataset, 
+and so these values need to be modified for each run.
+`"files.tar.gz"` is one giant tarball of the analysis files produced by a CellProfiler analysis run, 
+for example, something made using 
+```console
+tar -czvf files.tar.gz *
+```
+in a folder with all your output files (all the folders labeled by well names).
+
+To be concrete, the output of 
+```console
+tar -tzf files.tar.gz
+```
+is
+```console
+A01/
+A01/Experiment.csv
+A01/Cytoplasm.csv
+A01/Image.csv
+A01/Nuclei.csv
+A01/Cells.csv
+A01/outlines/
+A01/outlines/A01_s7--nuclei_outlines.png
+A01/outlines/A01_s9--cell_outlines.png
+A01/outlines/A01_s4--cell_outlines.png
+A01/outlines/A01_s2--nuclei_outlines.png
+A01/outlines/A01_s8--nuclei_outlines.png
+A01/outlines/A01_s7--cell_outlines.png
+A01/outlines/A01_s1--cell_outlines.png
+A01/outlines/A01_s9--nuclei_outlines.png
+A01/outlines/A01_s6--nuclei_outlines.png
+A01/outlines/A01_s3--nuclei_outlines.png
+A01/outlines/A01_s2--cell_outlines.png
+A01/outlines/A01_s3--cell_outlines.png
+A01/outlines/A01_s5--nuclei_outlines.png
+A01/outlines/A01_s6--cell_outlines.png
+A01/outlines/A01_s8--cell_outlines.png
+A01/outlines/A01_s5--cell_outlines.png
+A01/outlines/A01_s1--nuclei_outlines.png
+A01/outlines/A01_s4--nuclei_outlines.png
+A02/
+A02/Experiment.csv
+A02/Cytoplasm.csv
+A02/Image.csv
+A02/Nuclei.csv
+A02/Cells.csv
+A02/outlines/
+A02/outlines/A02_s6--nuclei_outlines.png
+A02/outlines/A02_s3--cell_outlines.png
+A02/outlines/A02_s3--nuclei_outlines.png
+A02/outlines/A02_s9--nuclei_outlines.png
+A02/outlines/A02_s8--cell_outlines.png
+A02/outlines/A02_s5--cell_outlines.png
+A02/outlines/A02_s6--cell_outlines.png
+A02/outlines/A02_s8--nuclei_outlines.png
+A02/outlines/A02_s7--nuclei_outlines.png
+A02/outlines/A02_s2--nuclei_outlines.png
+A02/outlines/A02_s1--nuclei_outlines.png
+A02/outlines/A02_s7--cell_outlines.png
+A02/outlines/A02_s4--nuclei_outlines.png
+A02/outlines/A02_s9--cell_outlines.png
+A02/outlines/A02_s4--cell_outlines.png
+A02/outlines/A02_s2--cell_outlines.png
+A02/outlines/A02_s5--nuclei_outlines.png
+A02/outlines/A02_s1--cell_outlines.png
+```
+when we are using a small example dataset with two wells `A01` and `A02`.
+
+Options JSON file:
+```json
+{
+  "write_to_cache": false,
+  "read_from_cache": false,
+  "final_workflow_outputs_dir": "cromwell_outputs",
+  "use_relative_output_paths": true,
+  "final_workflow_log_dir": "cromwell_outputs/wf_logs",
+  "final_call_logs_dir": "cromwell_outputs/call_logs"
+}
+```
+This file could be left as-is, if desired.
+These values specify options about a local cromwell run.
+For more information [see here.](https://cromwell.readthedocs.io/en/stable/wf_options/Overview)
+
+As configured, these options will not use call-caching, and they will copy output files to `cromwell_outputs`.
+Note that the outputs are _copied_, and so they also exist in the original location cromwell puts them: `cromwell-execution/`.
+If you want to delete that `cromwell-execution/` folder (to prevent duplication), you can do so.
+
+For comprehensive overview, see the following full example:
+
+```console
+(cromwell) $ ls
+data/
+inputs.json
+options.json
+
+(cromwell) $ ls data/
+A01/
+A01/Experiment.csv
+A01/Cytoplasm.csv
+A01/Image.csv
+A01/Nuclei.csv
+A01/Cells.csv
+A01/outlines/
+A01/outlines/A01_s7--nuclei_outlines.png
+A01/outlines/A01_s9--cell_outlines.png
+A01/outlines/A01_s4--cell_outlines.png
+A01/outlines/A01_s2--nuclei_outlines.png
+A01/outlines/A01_s8--nuclei_outlines.png
+A01/outlines/A01_s7--cell_outlines.png
+A01/outlines/A01_s1--cell_outlines.png
+A01/outlines/A01_s9--nuclei_outlines.png
+A01/outlines/A01_s6--nuclei_outlines.png
+A01/outlines/A01_s3--nuclei_outlines.png
+A01/outlines/A01_s2--cell_outlines.png
+A01/outlines/A01_s3--cell_outlines.png
+A01/outlines/A01_s5--nuclei_outlines.png
+A01/outlines/A01_s6--cell_outlines.png
+A01/outlines/A01_s8--cell_outlines.png
+A01/outlines/A01_s5--cell_outlines.png
+A01/outlines/A01_s1--nuclei_outlines.png
+A01/outlines/A01_s4--nuclei_outlines.png
+A02/
+A02/Experiment.csv
+A02/Cytoplasm.csv
+A02/Image.csv
+A02/Nuclei.csv
+A02/Cells.csv
+A02/outlines/
+A02/outlines/A02_s6--nuclei_outlines.png
+A02/outlines/A02_s3--cell_outlines.png
+A02/outlines/A02_s3--nuclei_outlines.png
+A02/outlines/A02_s9--nuclei_outlines.png
+A02/outlines/A02_s8--cell_outlines.png
+A02/outlines/A02_s5--cell_outlines.png
+A02/outlines/A02_s6--cell_outlines.png
+A02/outlines/A02_s8--nuclei_outlines.png
+A02/outlines/A02_s7--nuclei_outlines.png
+A02/outlines/A02_s2--nuclei_outlines.png
+A02/outlines/A02_s1--nuclei_outlines.png
+A02/outlines/A02_s7--cell_outlines.png
+A02/outlines/A02_s4--nuclei_outlines.png
+A02/outlines/A02_s9--cell_outlines.png
+A02/outlines/A02_s4--cell_outlines.png
+A02/outlines/A02_s2--cell_outlines.png
+A02/outlines/A02_s5--nuclei_outlines.png
+A02/outlines/A02_s1--cell_outlines.png
+
+(cromwell) $ tar -czvf files.tar.gz data/*
+
+(cromwell) $ ls
+data/
+inputs.json
+options.json
+files.tar.gz
+
+(cromwell) $ cromwell run cytomining.wdl -i inputs.json -o options.json
+<LOTS OF LOGS! ... wait until the task completes ...>
+
+(cromwell) $ ls
+cromwell_outputs/
+data/
+inputs.json
+options.json
+files.tar.gz
+
+(cromwell) $ ls cromwell_outputs/
+
+
+(cromwell) $ rm -r cromwell-*
+
+```
+
+You can also cause a local run to write outputs to a google bucket, if desired, 
+by supplying the input `cytomining.output_directory_gsurl` in `inputs.json`.

--- a/pipelines/mining/cytomining.wdl
+++ b/pipelines/mining/cytomining.wdl
@@ -8,216 +8,272 @@ import "../../utils/cellprofiler_distributed_utils.wdl" as util
 ## This script is released under the WDL source code license (BSD-3)
 ## (see LICENSE in https://github.com/openwdl/wdl).
 
-
 task profiling {
-  # A file that pipelines typically implicitly assume they have access to.
 
-  input {
-    # Input files
-    String cellprofiler_analysis_directory_gsurl
-    String plate_id
+    input {
+        # Input files
+        String? cellprofiler_analysis_directory
+        File? cellprofiler_analysis_tarball
+        String plate_id
+        String sqlite_file = ""
 
-    # Pycytominer aggregation step
-    String aggregation_operation = "mean"
-    Boolean add_image_features = false
-    Array[String] image_feature_categories = ["Intensity", "Granularity", "Texture", "ImageQuality", "Count", "Threshold"]
+        # Pycytominer aggregation step
+        String aggregation_operation = "mean"
+        Boolean add_image_features = false
+        Array[String] image_feature_categories = ["Intensity", "Granularity", "Texture", "ImageQuality", "Count", "Threshold"]
 
-    # Pycytominer annotation step
-    File plate_map_file
-    String? annotate_join_on = "['Metadata_well_position', 'Metadata_Well']"
+        # Pycytominer annotation step
+        File plate_map_file
+        String? annotate_join_on = "['Metadata_well_position', 'Metadata_Well']"
 
-    # Pycytominer normalize step
-    String? normalize_method = "mad_robustize"
-    Float? mad_robustize_epsilon = 0.0
+        # Pycytominer normalize step
+        String? normalize_method = "mad_robustize"
+        Float? mad_robustize_epsilon = 0.0
 
-    # Desired location of the outputs
-    String output_directory_gsurl
+        # Desired location of the outputs
+        String output_directory_gsurl = ""
 
-    # Hardware-related inputs
-    Int? hardware_memory_GB = 30
-    Int? hardware_preemptible_tries = 2
-  }
+        # Hardware-related inputs
+        Int? hardware_memory_GB = 30
+        Int? hardware_preemptible_tries = 2
+    }
 
-  # Ensure no trailing slashes
-  String cellprofiler_analysis_directory = sub(cellprofiler_analysis_directory_gsurl, "/+$", "")
-  String output_directory = sub(output_directory_gsurl, "/+$", "")
+    # Ensure no trailing slashes
+    String cellprofiler_analysis_dir = sub(select_first([cellprofiler_analysis_directory, ""]), "/+$", "")
+    String output_directory = sub(output_directory_gsurl, "/+$", "")
 
-  # Output filenames:
-  String agg_filename = plate_id + "_aggregated_" + aggregation_operation + ".csv"
-  String aug_filename = plate_id + "_annotated_" + aggregation_operation + ".csv"
-  String norm_filename = plate_id + "_normalized_" + aggregation_operation + ".csv"
+    # Output filenames:
+    String agg_filename = plate_id + "_aggregated_" + aggregation_operation + ".csv"
+    String aug_filename = plate_id + "_annotated_" + aggregation_operation + ".csv"
+    String norm_filename = plate_id + "_normalized_" + aggregation_operation + ".csv"
+    String sqlite_filename = plate_id + ".sqlite"
 
-  command <<<
+    command <<<
 
-    set -e
+        set -e
 
-    # run monitoring script
-    monitor_script.sh > monitoring.log &
+        # run monitoring script
+        monitor_script.sh > monitoring.log &
 
-    # display for log
-    echo "Localizing data from ~{cellprofiler_analysis_directory}"
-    start=`date +%s`
-    echo $start
+        # download some necessary files from github
+        wget -O ingest_config.ini https://raw.githubusercontent.com/broadinstitute/cytominer_scripts/master/ingest_config.ini
+        wget -O indices.sql https://raw.githubusercontent.com/broadinstitute/cytominer_scripts/master/indices.sql
 
-    # localize the data
-    mkdir -p /cromwell_root/data
-    gsutil -mq rsync -r -x ".*\.png$" ~{cellprofiler_analysis_directory} /cromwell_root/data
-    wget -O ingest_config.ini https://raw.githubusercontent.com/broadinstitute/cytominer_scripts/master/ingest_config.ini
-    wget -O indices.sql https://raw.githubusercontent.com/broadinstitute/cytominer_scripts/master/indices.sql
+        local_directory="/cromwell_root/data"
 
-    # display for log
-    end=`date +%s`
-    echo $end
-    runtime=$((end-start))
-    echo "Total runtime for file localization:"
-    echo $runtime
+        if [[ "~{sqlite_file}" == "" ]]; then
 
-    # display for log
-    echo " "
-    echo "ls -lh /cromwell_root/data"
-    ls -lh /cromwell_root/data
+            if [[ "~{cellprofiler_analysis_dir}" == "gs://*" ]]; then
 
-    # display for log
-    echo " "
-    echo "ls -lh ."
-    ls -lh .
+                # display for log
+                echo "Localizing data from ~{cellprofiler_analysis_dir}"
+                start=`date +%s`
+                echo $start
 
-    # display for log
-    echo " "
-    echo "===================================="
-    echo "= Running cytominer-databse ingest ="
-    echo "===================================="
-    start=`date +%s`
-    echo $start
-    echo "cytominer-database ingest /cromwell_root/data sqlite:///~{plate_id}.sqlite -c ingest_config.ini"
+                # localize the data
+                mkdir -p ${local_directory}
+                gsutil -mq rsync -r -x ".*\.png$" ~{cellprofiler_analysis_dir} ${local_directory}
 
-    # run the very long SQLite database ingestion code
-    cytominer-database ingest /cromwell_root/data sqlite:///~{plate_id}.sqlite -c ingest_config.ini
-    sqlite3 ~{plate_id}.sqlite < indices.sql
+                # display for log
+                end=`date +%s`
+                echo $end
+                runtime=$((end-start))
+                echo "Total runtime for file localization:"
+                echo $runtime
 
-    # Copying sqlite
-    echo "Copying sqlite file to ~{output_directory}"
-    gsutil cp ~{plate_id}.sqlite ~{output_directory}/
+                # display for log
+                echo " "
+                echo "ls -lh ${local_directory}"
+                ls -lh ${local_directory}
 
-    # display for log
-    end=`date +%s`
-    echo $end
-    runtime=$((end-start))
-    echo "Total runtime for cytominer-database ingest:"
-    echo $runtime
-    echo "===================================="
+            else
 
-    # run the python code right here for pycytominer aggregation
-    echo " "
-    echo "Running pycytominer aggregation step"
-    python <<CODE
+                echo "Local data from ~{cellprofiler_analysis_tarball}"
+                echo "Unpacking tarball"
+                mkdir -p ${local_directory}
+                echo "tar -xvzf ~{cellprofiler_analysis_tarball} -C ${local_directory}"
+                tar -xvzf ~{cellprofiler_analysis_tarball} -C ${local_directory}
 
-    import time
-    import pandas as pd
-    from pycytominer.cyto_utils.cells import SingleCells
-    from pycytominer.cyto_utils import infer_cp_features
-    from pycytominer import normalize, annotate
+            fi
 
-    IMAGE_FEATURE_CATEGORIES = ["~{sep='","' image_feature_categories}"]
+            # display for log
+            echo " "
+            echo "ls -lh ."
+            ls -lh .
 
-    print("Creating Single Cell class... ")
-    start = time.time()
-    sc = SingleCells(
-        'sqlite:///~{plate_id}.sqlite',
-        aggregation_operation='~{aggregation_operation}',
-        add_image_features=~{if add_image_features then "True" else "False"},
-        image_feature_categories=IMAGE_FEATURE_CATEGORIES)
-    print("Time: " + str(time.time() - start))
+            # display for log
+            echo " "
+            echo "===================================="
+            echo "= Running cytominer-databse ingest ="
+            echo "===================================="
+            echo "local_directory is ${local_directory}"
+            start=`date +%s`
+            echo $start
+            echo "cytominer-database ingest ${local_directory} sqlite:///~{sqlite_filename} -c ingest_config.ini"
 
-    print("Aggregating profiles... ")
-    start = time.time()
-    aggregated_df = sc.aggregate_profiles()
-    aggregated_df.to_csv('~{agg_filename}', index=False)
-    print("Time: " + str(time.time() - start))
+            # run the very long SQLite database ingestion code
+            cytominer-database ingest ${local_directory} sqlite:///~{sqlite_filename} -c ingest_config.ini
+            sqlite3 ~{sqlite_filename} < indices.sql
+            sqlite_file="sqlite:///~{sqlite_filename}"
 
-    print("Annotating with metadata... ")
-    start = time.time()
-    plate_map_df = pd.read_csv('~{plate_map_file}', sep="\t")
-    annotated_df = annotate(aggregated_df, plate_map_df, join_on = ~{annotate_join_on})
-    annotated_df.to_csv('~{aug_filename}',index=False)
-    print("Time: " + str(time.time() - start))
+            if [[ "~{output_directory}" == "gs://*" ]]; then
 
-    print("Normalizing to plate.. ")
-    start = time.time()
-    normalize(annotated_df, method='~{normalize_method}', mad_robustize_epsilon = ~{mad_robustize_epsilon}).to_csv('~{norm_filename}',index=False)
-    print("Time: " + str(time.time() - start))
+                # Copying sqlite
+                echo "Copying sqlite file to ~{output_directory}"
+                gsutil cp ~{sqlite_filename} ~{output_directory}/
 
-    CODE
+            fi
 
-    # display for log
-    echo " "
-    echo "Completed pycytominer aggregation annotation & normalization"
-    echo "ls -lh ."
-    ls -lh .
+            # display for log
+            end=`date +%s`
+            echo $end
+            runtime=$((end-start))
+            echo "Total runtime for cytominer-database ingest:"
+            echo $runtime
+            echo "===================================="
 
-    echo "Copying csv outputs to ~{output_directory}"
-    gsutil cp ~{agg_filename} ~{output_directory}/
-    gsutil cp ~{aug_filename} ~{output_directory}/
-    gsutil cp ~{norm_filename} ~{output_directory}/
-    gsutil cp monitoring.log ~{output_directory}/
+        else
 
-    echo "Done."
+            sqlite_file="~{sqlite_file}"
 
-  >>>
+        fi
 
-  output {
-    File monitoring_log = "monitoring.log"
-    File log = stdout()
-  }
+        # run the python code right here for pycytominer aggregation
+        echo " "
+        echo "Running pycytominer aggregation step"
+        python <<CODE
 
-  runtime {
-    docker: "us.gcr.io/broad-dsde-methods/cytomining:0.0.4"
-    disks: "local-disk 500 HDD"
-    memory: "${hardware_memory_GB}G"
-    bootDiskSizeGb: 10
-    cpu: 4
-    maxRetries: 2
-    preemptible: hardware_preemptible_tries
-  }
+        import time
+        import pandas as pd
+        from pycytominer.cyto_utils.cells import SingleCells
+        from pycytominer.cyto_utils import infer_cp_features
+        from pycytominer import normalize, annotate
+
+        IMAGE_FEATURE_CATEGORIES = ["~{sep='","' image_feature_categories}"]
+
+        print("Creating Single Cell class... ")
+        start = time.time()
+        sc = SingleCells(
+            '${sqlite_file}',
+            aggregation_operation='~{aggregation_operation}',
+            add_image_features=~{if add_image_features then "True" else "False"},
+            image_feature_categories=IMAGE_FEATURE_CATEGORIES)
+        print("Time: " + str(time.time() - start))
+
+        print("Aggregating profiles... ")
+        start = time.time()
+        aggregated_df = sc.aggregate_profiles()
+        aggregated_df.to_csv('~{agg_filename}', index=False)
+        print("Time: " + str(time.time() - start))
+
+        print("Annotating with metadata... ")
+        start = time.time()
+        plate_map_df = pd.read_csv('~{plate_map_file}', sep="\t")
+        annotated_df = annotate(aggregated_df, plate_map_df, join_on = ~{annotate_join_on})
+        annotated_df.to_csv('~{aug_filename}',index=False)
+        print("Time: " + str(time.time() - start))
+
+        print("Normalizing to plate.. ")
+        start = time.time()
+        normalize(annotated_df, method='~{normalize_method}', mad_robustize_epsilon = ~{mad_robustize_epsilon}).to_csv('~{norm_filename}',index=False)
+        print("Time: " + str(time.time() - start))
+
+        CODE
+
+        # display for log
+        echo " "
+        echo "Completed pycytominer aggregation annotation & normalization"
+        echo "ls -lh ."
+        ls -lh .
+
+        if [[ "~{output_directory_gsurl}" != "" ]]; then
+
+            echo "Copying csv outputs to ~{output_directory}"
+            gsutil cp ~{agg_filename} ~{output_directory}/
+            gsutil cp ~{aug_filename} ~{output_directory}/
+            gsutil cp ~{norm_filename} ~{output_directory}/
+            gsutil cp monitoring.log ~{output_directory}/
+
+        fi
+
+        echo "Done."
+
+    >>>
+
+    output {
+        File monitoring_log = "monitoring.log"
+        File log = stdout()
+        File sqlite = sqlite_filename
+        File aggregated_csv = aug_filename
+        File aggregated_normalized_csv = norm_filename
+    }
+
+    runtime {
+        docker: "us.gcr.io/broad-dsde-methods/cytomining:0.0.4"
+        disks: "local-disk 500 HDD"
+        memory: "${hardware_memory_GB}G"
+        bootDiskSizeGb: 10
+        cpu: 4
+        maxRetries: 0
+        preemptible: hardware_preemptible_tries
+    }
 
 }
 
-
 workflow cytomining {
-  input {
-    String cellprofiler_analysis_directory_gsurl
-    String plate_id
+    input {
+        String? cellprofiler_analysis_directory = ""
+        String? cellprofiler_analysis_tarball
+        String plate_id
 
-    # Pycytominer annotation step
-    File plate_map_file
+        # Pycytominer annotation step
+        File plate_map_file
 
-    # Desired location of the outputs
-    String output_directory_gsurl
-  }
-
-  # check write permission on output bucket
-  call util.gcloud_is_bucket_writable as permission_check {
-    input:
-      gsurls=[output_directory_gsurl],
-  }
-
-  # run the compute only if output bucket is writable
-  Boolean is_bucket_writable = permission_check.is_bucket_writable
-  if (is_bucket_writable) {
-
-    call profiling {
-      input:
-        cellprofiler_analysis_directory_gsurl = cellprofiler_analysis_directory_gsurl,
-        plate_id = plate_id,
-        plate_map_file = plate_map_file,
-        output_directory_gsurl = output_directory_gsurl,
+        # Desired location of the outputs
+        String? output_directory_gsurl
     }
 
-  }
+    Boolean is_output_directory_specified = defined(output_directory_gsurl)
+    if (is_output_directory_specified) {
+        String directory = select_first([output_directory_gsurl, ""])
+        # check write permission on output bucket
+        call util.gcloud_is_bucket_writable as permission_check {
+            input:
+                gsurls=[directory],
+        }
+    }
 
-  output {
-    File monitoring_log = select_first([profiling.monitoring_log, permission_check.log])
-    File log = select_first([profiling.log, permission_check.log])
-  }
+    # run the compute only if output bucket is writable
+    Boolean use_tarball = defined(cellprofiler_analysis_tarball)
+    Boolean is_bucket_writable = select_first([permission_check.is_bucket_writable, true])
+    if (is_bucket_writable) {
+        if (use_tarball) {
+            call profiling {
+                input:
+                    cellprofiler_analysis_tarball = cellprofiler_analysis_tarball,
+                    plate_id = plate_id,
+                    plate_map_file = plate_map_file,
+                    output_directory_gsurl = output_directory_gsurl,
+            }
+        }
+        if (!use_tarball) {
+            call profiling as profiling_gsurl {
+                input:
+                    cellprofiler_analysis_directory = cellprofiler_analysis_directory,
+                    plate_id = plate_id,
+                    plate_map_file = plate_map_file,
+                    output_directory_gsurl = output_directory_gsurl,
+            }
+        }
+
+    }
+
+    output {
+        File monitoring_log = select_first([profiling.monitoring_log, profiling_gsurl.monitoring_log, permission_check.log])
+        File log = select_first([profiling.log, profiling_gsurl.log, permission_check.log])
+        File sqlite = select_first([profiling.sqlite, profiling_gsurl.sqlite, permission_check.log])
+        File aggregated_csv = select_first([profiling.aggregated_csv, profiling_gsurl.aggregated_csv, permission_check.log])
+        File aggregated_normalized_csv = select_first([profiling.aggregated_normalized_csv, profiling_gsurl.aggregated_normalized_csv, permission_check.log])
+    }
 
 }

--- a/pipelines/mining/cytomining.wdl
+++ b/pipelines/mining/cytomining.wdl
@@ -12,7 +12,7 @@ task profiling {
 
     input {
         # Input files
-        String? cellprofiler_analysis_directory
+        String? cellprofiler_analysis_directory_gsurl
         File? cellprofiler_analysis_tarball
         String plate_id
         String sqlite_file = ""
@@ -39,7 +39,7 @@ task profiling {
     }
 
     # Ensure no trailing slashes
-    String cellprofiler_analysis_dir = sub(select_first([cellprofiler_analysis_directory, ""]), "/+$", "")
+    String cellprofiler_analysis_dir = sub(select_first([cellprofiler_analysis_directory_gsurl, ""]), "/+$", "")
     String output_directory = sub(output_directory_gsurl, "/+$", "")
 
     # Output filenames:
@@ -222,7 +222,7 @@ task profiling {
 
 workflow cytomining {
     input {
-        String? cellprofiler_analysis_directory = ""
+        String? cellprofiler_analysis_directory_gsurl
         String? cellprofiler_analysis_tarball
         String plate_id
 
@@ -259,7 +259,7 @@ workflow cytomining {
         if (!use_tarball) {
             call profiling as profiling_gsurl {
                 input:
-                    cellprofiler_analysis_directory = cellprofiler_analysis_directory,
+                    cellprofiler_analysis_directory_gsurl = cellprofiler_analysis_directory_gsurl,
                     plate_id = plate_id,
                     plate_map_file = plate_map_file,
                     output_directory_gsurl = output_directory_gsurl,

--- a/pipelines/mining/inputs.json
+++ b/pipelines/mining/inputs.json
@@ -1,0 +1,6 @@
+{
+  "cytomining.cellprofiler_analysis_tarball": "files.tar.gz",
+  "cytomining.plate_map_file": "JUMP-Target-1_compound_platemap.tsv",
+  "cytomining.plate_id": "BR00116991"
+}
+

--- a/pipelines/mining/options.json
+++ b/pipelines/mining/options.json
@@ -1,0 +1,8 @@
+{
+  "write_to_cache": false,
+  "read_from_cache": false,
+  "final_workflow_outputs_dir": "cromwell_outputs",
+  "use_relative_output_paths": true,
+  "final_workflow_log_dir": "cromwell_outputs/wf_logs",
+  "final_call_logs_dir": "cromwell_outputs/call_logs"
+}


### PR DESCRIPTION
The idea here was to enable people (mainly developers?) to run the `cytomining` workflow locally, for instance on a laptop.  This might be useful for other users too, who don't want to set up Terra, and who have CellProfiler data around.  It does seem like kind of an easy way to run `cytominer` and `pycytominer` without having to worry about any setup or install.  (The only thing you have to install is `cromwell`, and that's a painless one-liner.)

The user experience would look like this:

0. (download the data to your local machine)
1. make a huge tarball from the whole dataset (I'm kind of annoyed that this step is necessary, but I cannot figure out a way around it)
2. run `cromwell run cytomining.wdl -i inputs.json -o options.json`
3. wait for it to complete, and see the results appear in the local folder called `cromwell_outputs/`

NOTE: I have not done any testing to make sure I didn't break the normal functionality of `cytomining.wdl`.  @carmendv can you check that if you get a chance?

I'd also appreciate your feedback @deflaux , though I can't tag you as a reviewer.

Future TODO: since this is a workflow that runs locally, we could very easily have a GitHub action test this workflow as part of our continuous integration tests.